### PR TITLE
configure logging from client

### DIFF
--- a/dusty/cli/__init__.py
+++ b/dusty/cli/__init__.py
@@ -27,6 +27,7 @@ import socket
 from docopt import docopt
 
 from ..constants import SOCKET_PATH, SOCKET_TERMINATOR, SOCKET_ERROR_TERMINATOR
+from ..log import configure_client_logging
 from ..payload import Payload
 from . import bundles, config, cp, dump, disk, logs, repos, restart, script, shell, stop, sync, up
 
@@ -85,6 +86,7 @@ def main():
         print "\n{}".format(__doc__.strip())
         sys.exit(1)
 
+    configure_client_logging()
     result = MODULE_MAP[command].main(command_args)
     if isinstance(result, Payload):
         sock = _connect_to_daemon()

--- a/dusty/log.py
+++ b/dusty/log.py
@@ -37,3 +37,7 @@ def close_socket_logger():
     logger = logging.getLogger(SOCKET_LOGGER_NAME)
     logger.removeHandler(handler)
     handler = None
+
+def configure_client_logging():
+    logging.basicConfig(stream=sys.stdout,
+                        level=logging.INFO)


### PR DESCRIPTION
@paetling log to stdout on client.  `log_to_client` will now log normally to stdout when run on client side
