### PR TITLE
Massive refactor of Repo management

### DIFF
--- a/dusty/commands/repos.py
+++ b/dusty/commands/repos.py
@@ -4,56 +4,48 @@ from prettytable import PrettyTable
 
 from ..config import get_config_value, save_config_value
 from ..compiler.spec_assembler import get_specs, get_specs_repo, get_all_repos, get_assembled_specs
-from ..source import update_local_repo, short_repo_name, get_expanded_repo_name
+from ..source import Repo
 from ..log import log_to_client
 from .. import constants
-
 
 def list_repos():
     repos, overrides = get_all_repos(), get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY)
     table = PrettyTable(['Full Name', 'Short Name', 'Local Override'])
     for repo in repos:
-        table.add_row([repo, short_repo_name(repo),
-                       overrides[repo] if repo in overrides else ''])
+        table.add_row([repo.remote_path, repo.short_name,
+                       repo.override_path if repo.is_overridden else ''])
     log_to_client(table.get_string(sortby='Full Name'))
 
 def override_repo(repo_name, source_path):
-    repo_name = get_expanded_repo_name(repo_name)
-    repos = get_all_repos()
-    if repo_name not in repos:
-        raise KeyError('No repo registered named {}'.format(repo_name))
+    repo = Repo.resolve(get_all_repos(), repo_name)
     if not os.path.exists(source_path):
         raise OSError('Source path {} does not exist'.format(source_path))
     config = get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY)
-    config[repo_name] = source_path
+    config[repo.remote_path] = source_path
     save_config_value(constants.CONFIG_REPO_OVERRIDES_KEY, config)
-    log_to_client('Locally overriding repo {} to use source at {}'.format(repo_name, source_path))
+    log_to_client('Locally overriding repo {} to use source at {}'.format(repo.remote_path, source_path))
 
 def manage_repo(repo_name):
-    repo_name = get_expanded_repo_name(repo_name)
-    repos = get_all_repos()
-    if repo_name not in repos:
-        raise KeyError('No repo registered named {}'.format(repo_name))
+    repo = Repo.resolve(get_all_repos(), repo_name)
     config = get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY)
-    if repo_name in config:
-        del config[repo_name]
+    if repo.remote_path in config:
+        del config[repo.remote_path]
     save_config_value(constants.CONFIG_REPO_OVERRIDES_KEY, config)
-    log_to_client('Will manage repo {} with Dusty-managed copy of source'.format(repo_name))
+    log_to_client('Will manage repo {} with Dusty-managed copy of source'.format(repo.remote_path))
 
 def override_repos_from_directory(source_path):
     log_to_client('Overriding all repos found at {}'.format(source_path))
     for repo in get_all_repos():
-        repo_name = repo.split('/')[-1]
-        repo_path = os.path.join(source_path, repo_name)
+        repo_path = os.path.join(source_path, repo.short_name)
         if os.path.isdir(repo_path):
-            override_repo(repo, repo_path)
+            override_repo(repo.remote_path, repo_path)
 
 def update_managed_repos():
     """For any active, managed repos, update the Dusty-managed
     copy to bring it up to date with the latest master."""
     log_to_client('Pulling latest updates for all active managed repos:')
     overrides = set(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY))
-    for repo_name in get_all_repos(active_only=True):
-        if repo_name not in overrides:
-            log_to_client('Updating managed copy of {}'.format(repo_name))
-            update_local_repo(repo_name)
+    for repo in get_all_repos(active_only=True):
+        if not repo.is_overridden:
+            log_to_client('Updating managed copy of {}'.format(repo.remote_path))
+            repo.update_local_repo()

--- a/dusty/compiler/compose/__init__.py
+++ b/dusty/compiler/compose/__init__.py
@@ -3,7 +3,8 @@ import logging
 import yaml
 
 from ..spec_assembler import get_assembled_specs
-from ...path import vm_repo_path, vm_cp_path
+from ...path import vm_cp_path
+from ...source import Repo
 from ... import constants
 
 def get_compose_dict(assembled_specs, port_specs):
@@ -130,8 +131,7 @@ def _get_cp_volume_mount(app_name):
 def _get_app_volume_mount(app_spec):
     """ This returns the formatted volume mount spec to mount the local code for an app in the
     container """
-    app_repo_path = vm_repo_path(app_spec['repo'])
-    return "{}:{}".format(app_repo_path, _container_code_path(app_spec))
+    return "{}:{}".format(Repo(app_spec['repo']).vm_path, _container_code_path(app_spec))
 
 def _container_code_path(spec):
     """ Returns the path inside the docker container that a spec (for an app or lib) says it wants
@@ -143,6 +143,5 @@ def _get_libs_volume_mounts(app_name, assembled_specs):
     volumes = []
     for lib_name in assembled_specs['apps'][app_name].get('depends', {}).get('libs', []):
         lib_spec = assembled_specs['libs'][lib_name]
-        lib_repo_path = vm_repo_path(lib_spec['repo'])
-        volumes.append("{}:{}".format(lib_repo_path, _container_code_path(lib_spec)))
+        volumes.append("{}:{}".format(Repo(lib_spec['repo']).vm_path, _container_code_path(lib_spec)))
     return volumes

--- a/dusty/compiler/spec_assembler.py
+++ b/dusty/compiler/spec_assembler.py
@@ -4,9 +4,8 @@ import yaml
 import logging
 
 from ..config import get_config_value
-from ..path import local_repo_path
 from .. import constants
-
+from ..source import Repo
 
 def _get_dependent(dependent_type, name, specs, root_spec_type):
     """
@@ -105,10 +104,10 @@ def get_assembled_specs():
     return specs
 
 def get_specs_repo():
-    return get_config_value(constants.CONFIG_SPECS_REPO_KEY)
+    return Repo(get_config_value(constants.CONFIG_SPECS_REPO_KEY))
 
 def get_specs_path():
-    return local_repo_path(get_specs_repo())
+    return get_specs_repo().local_path
 
 def get_specs():
     specs_path = get_specs_path()
@@ -143,5 +142,5 @@ def get_all_repos(active_only=False, include_specs_repo=True):
     for type_key in ['apps', 'libs']:
         for spec in specs[type_key].itervalues():
             if 'repo' in spec:
-                repos.add(spec['repo'])
+                repos.add(Repo(spec['repo']))
     return repos

--- a/dusty/path.py
+++ b/dusty/path.py
@@ -8,18 +8,5 @@ def parent_dir(path):
     prior to creating a file."""
     return os.path.split(path)[0]
 
-def local_repo_path(repo_name):
-    """Given a repo_name (github.com/gamechanger/gclib), checks if that repo has an
-    override, and returns the appropriate directory"""
-    repo_overrides = get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY)
-    override_dir = repo_overrides.get(repo_name)
-    return override_dir if override_dir else managed_repo_path(repo_name)
-
-def vm_repo_path(repo_name):
-    return os.path.join(constants.VM_REPOS_DIR, repo_name)
-
-def managed_repo_path(repo_name):
-    return os.path.join(constants.REPOS_DIR, repo_name)
-
 def vm_cp_path(repo_name):
     return os.path.join(constants.VM_CP_DIR, repo_name)

--- a/dusty/systems/rsync/__init__.py
+++ b/dusty/systems/rsync/__init__.py
@@ -5,8 +5,8 @@ from subprocess import check_call, CalledProcessError
 from ... import constants
 from ...config import get_config_value
 from ...demote import check_call_demoted, check_and_log_output_and_error_demoted
-from ...source import repo_is_overridden, get_expanded_repo_name
-from ...path import local_repo_path, vm_repo_path, parent_dir
+from ...source import Repo
+from ...path import parent_dir
 from ...log import log_to_client
 from dusty.compiler.spec_assembler import get_repo_of_app_or_library, get_assembled_specs
 
@@ -49,12 +49,10 @@ def sync_local_path_from_vm(local_path, remote_path, demote=False, is_dir=True):
 
 def sync_repos(repos):
     logging.info('Syncing repos over rsync')
-    for repo_name in repos:
-        repo_name = get_expanded_repo_name(repo_name)
-        repo_type = 'overridden' if repo_is_overridden(repo_name) else 'Dusty-managed'
-        remote_path = vm_repo_path(repo_name)
-        log_to_client('Syncing {} repo {} to remote at {}'.format(repo_type, repo_name, remote_path))
-        sync_local_path_to_vm(local_repo_path(repo_name), remote_path)
+    for repo in repos:
+        repo_type = 'overridden' if repo.is_overridden else 'Dusty-managed'
+        log_to_client('Syncing {} repo {} to remote at {}'.format(repo_type, repo.remote_path, repo.vm_path))
+        sync_local_path_to_vm(repo.local_path, repo.vm_path)
 
 def sync_repos_by_app_name(app_names):
     repos = set()

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -33,7 +33,7 @@ class DustyTestCase(TestCase):
         constants.CONFIG_PATH = self.temp_config_path
         write_default_config()
         save_config_value(constants.CONFIG_SPECS_REPO_KEY, 'github.com/org/dusty-specs')
-        override_repo(get_specs_repo(), self.temp_specs_path)
+        override_repo(get_specs_repo().remote_path, self.temp_specs_path)
         basic_specs_fixture()
 
         self.client_output = []

--- a/tests/unit/commands/repos_test.py
+++ b/tests/unit/commands/repos_test.py
@@ -51,32 +51,36 @@ class TestReposCommands(DustyTestCase):
 
     def test_override_repo(self):
         override_repo('github.com/app/a', self.temp_specs_path)
-        self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY), {get_specs_repo(): self.temp_specs_path,
-                                                                   'github.com/app/a': self.temp_specs_path})
+        self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY),
+                              {get_specs_repo().remote_path: self.temp_specs_path,
+                               'github.com/app/a': self.temp_specs_path})
 
     def test_override_then_manage_repo(self):
         override_repo('github.com/app/a', self.temp_specs_path)
-        self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY), {get_specs_repo(): self.temp_specs_path,
-                                                                   'github.com/app/a': self.temp_specs_path})
+        self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY),
+                              {get_specs_repo().remote_path: self.temp_specs_path,
+                               'github.com/app/a': self.temp_specs_path})
         manage_repo('github.com/app/a')
-        self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY), {get_specs_repo(): self.temp_specs_path})
+        self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY),
+                              {get_specs_repo().remote_path: self.temp_specs_path})
 
     def test_override_repos_from_directory(self):
         override_repos_from_directory(self.temp_repos_path)
-        self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY), {get_specs_repo(): self.temp_specs_path,
-                                                                   'github.com/app/a': os.path.join(self.temp_repos_path, 'a'),
-                                                                   'github.com/app/b': os.path.join(self.temp_repos_path, 'b'),
-                                                                   'github.com/lib/a': os.path.join(self.temp_repos_path, 'a')})
+        self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY),
+                              {get_specs_repo().remote_path: self.temp_specs_path,
+                               'github.com/app/a': os.path.join(self.temp_repos_path, 'a'),
+                               'github.com/app/b': os.path.join(self.temp_repos_path, 'b'),
+                               'github.com/lib/a': os.path.join(self.temp_repos_path, 'a')})
 
-    @patch('dusty.commands.repos.update_local_repo')
+    @patch('dusty.source.Repo.update_local_repo')
     def test_update_managed_repos(self, fake_update_local_repo):
         activate_bundle(['bundle-a'])
         update_managed_repos()
-        fake_update_local_repo.assert_called_once_with('github.com/app/a')
+        fake_update_local_repo.assert_called_once_with()
 
-    @patch('dusty.commands.repos.update_local_repo')
+    @patch('dusty.source.Repo.update_local_repo')
     def test_update_managed_repos_for_both(self, fake_update_local_repo):
         activate_bundle(['bundle-a'])
         activate_bundle(['bundle-b'])
         update_managed_repos()
-        fake_update_local_repo.assert_has_calls([call('github.com/app/a'), call('github.com/app/b')])
+        fake_update_local_repo.assert_has_calls([call(), call()])

--- a/tests/unit/commands/run_test.py
+++ b/tests/unit/commands/run_test.py
@@ -1,6 +1,7 @@
 from mock import patch, call
 
 from dusty.commands.run import restart_apps_or_services
+from dusty.source import Repo
 from ...testcases import DustyTestCase
 
 class TestRunCommands(DustyTestCase):
@@ -81,7 +82,8 @@ class TestRunCommands(DustyTestCase):
         fake_get_assembled_specs.return_value = self.specs
         fake_get_specs.return_value = self.specs
         restart_apps_or_services()
-        fake_rsync.sync_repos.assert_has_calls([call(set(['github.com/app/a', 'github.com/app/b', 'github.com/lib/a', 'github.com/lib/b']))])
+        fake_rsync.sync_repos.assert_has_calls([call(set([Repo('github.com/app/a'), Repo('github.com/app/b'),
+                                                          Repo('github.com/lib/a'), Repo('github.com/lib/b')]))])
 
     @patch('dusty.commands.run.docker.compose.restart_running_services')
     @patch('dusty.commands.run.rsync')

--- a/tests/unit/commands/sync_test.py
+++ b/tests/unit/commands/sync_test.py
@@ -2,6 +2,7 @@ from mock import patch, call
 
 from dusty.commands.sync import sync_repos
 from dusty.commands.bundles import activate_bundle
+from dusty.source import Repo
 from ...testcases import DustyTestCase
 
 class TestSyncCommand(DustyTestCase):
@@ -13,7 +14,7 @@ class TestSyncCommand(DustyTestCase):
     @patch('dusty.commands.sync.perform_sync_repos')
     def test_sync_repos_no_args(self, fake_sync):
         sync_repos()
-        fake_sync.assert_has_calls([call(set(['github.com/app/a', 'github.com/app/b']))])
+        fake_sync.assert_has_calls([call(set([Repo('github.com/app/a'), Repo('github.com/app/b')]))])
 
     @patch('dusty.commands.sync.perform_sync_repos')
     def test_sync_repos_with_one_arg(self, fake_sync):

--- a/tests/unit/compiler/compose/test.py
+++ b/tests/unit/compiler/compose/test.py
@@ -11,7 +11,7 @@ from ....testcases import DustyTestCase
 basic_specs = {
     'apps': {
         'app1': {
-            'repo': '/cool/repo/app1',
+            'repo': '/app1',
             'depends': {
                 'libs': ['lib1', 'lib2'],
                 'services': ['service1', 'service2'],
@@ -27,12 +27,12 @@ basic_specs = {
     },
     'libs': {
         'lib1': {
-            'repo': '/cool/repo/lib1',
+            'repo': '/lib1',
             'mount': '/gc/lib1',
             'install': './install.sh'
         },
         'lib2': {
-            'repo': '/cool/repo/lib2',
+            'repo': '/lib2',
             'mount': '/gc/lib2',
             'install': 'python setup.py develop'
         }
@@ -57,12 +57,16 @@ basic_port_specs = {
     }
 }
 
-
-def vm_repo_path(name):
-    return "/Users/gc/{}".format(name.split('/')[-1])
-
-@patch('dusty.compiler.compose.vm_repo_path', side_effect=vm_repo_path)
 class TestComposeCompiler(DustyTestCase):
+    def setUp(self):
+        super(TestComposeCompiler, self).setUp()
+        self.old_vm_repos_dir = constants.VM_REPOS_DIR
+        constants.VM_REPOS_DIR = '/Users/gc'
+
+    def tearDown(self):
+        super(TestComposeCompiler, self).tearDown()
+        constants.VM_REPOS_DIR = self.old_vm_repos_dir
+
     def test_composed_volumes(self, *args):
         expected_volumes = [
             '/cp/app1:/cp',

--- a/tests/unit/path_test.py
+++ b/tests/unit/path_test.py
@@ -3,7 +3,8 @@ import shutil
 
 from ..testcases import DustyTestCase
 from dusty.commands.repos import override_repo
-from dusty.path import parent_dir, local_repo_path
+from dusty.path import parent_dir
+from dusty.source import Repo
 
 class TestPath(DustyTestCase):
     def setUp(self):
@@ -15,12 +16,12 @@ class TestPath(DustyTestCase):
         shutil.rmtree(self.temp_dir)
 
     def test_local_repo_path_no_override(self):
-        self.assertEqual(local_repo_path('github.com/app/a'),
+        self.assertEqual(Repo('github.com/app/a').local_path,
                          '/etc/dusty/repos/github.com/app/a')
 
     def test_local_repo_path_with_override(self):
         override_repo('github.com/app/a', self.temp_dir)
-        self.assertEqual(local_repo_path('github.com/app/a'), self.temp_dir)
+        self.assertEqual(Repo('github.com/app/a').local_path, self.temp_dir)
 
     def test_parent_dir_on_dir(self):
         self.assertEqual(parent_dir('/some/long/dir'), '/some/long')

--- a/tests/unit/source_test.py
+++ b/tests/unit/source_test.py
@@ -7,14 +7,14 @@ from mock import Mock, patch
 
 from ..testcases import DustyTestCase
 from dusty.commands.repos import override_repo
-from dusty.source import (repo_is_overridden, short_repo_name,
-                          git_error_handling, ensure_local_repo, update_local_repo,
-                          _expand_repo_name)
+from dusty.source import Repo, git_error_handling
 
 class TestSource(DustyTestCase):
     def setUp(self):
         super(TestSource, self).setUp()
         self.temp_dir = tempfile.mkdtemp()
+
+        self.MockableRepo = type("MockableRepo", (Repo, object), {})
 
     def tearDown(self):
         super(TestSource, self).tearDown()
@@ -22,13 +22,13 @@ class TestSource(DustyTestCase):
 
     def test_repo_is_overridden_true(self):
         override_repo('github.com/app/a', self.temp_dir)
-        self.assertTrue(repo_is_overridden('github.com/app/a'))
+        self.assertTrue(Repo('github.com/app/a').is_overridden)
 
     def test_repo_is_overridden_false(self):
-        self.assertFalse(repo_is_overridden('github.com/app/a'))
+        self.assertFalse(Repo('github.com/app/a').is_overridden)
 
     def test_short_repo_name(self):
-        self.assertEqual(short_repo_name('github.com/app/a'), 'a')
+        self.assertEqual(Repo('github.com/app/a').short_name, 'a')
 
     @patch('dusty.source.log_to_client')
     def test_git_error_handling(self, fake_log_to_client):
@@ -38,43 +38,24 @@ class TestSource(DustyTestCase):
         self.assertTrue(fake_log_to_client.called)
 
     @patch('git.Repo.clone_from')
-    @patch('dusty.source.managed_repo_path')
-    def test_ensure_local_repo_when_does_not_exist(self, fake_repo_path, fake_clone_from):
+    def test_ensure_local_repo_when_does_not_exist(self, fake_clone_from):
         temp_dir = os.path.join(self.temp_dir, 'a')
-        fake_repo_path.return_value = temp_dir
-        ensure_local_repo('github.com/app/a')
+        self.MockableRepo.managed_path = property(lambda repo: temp_dir)
+        self.MockableRepo('github.com/app/a').ensure_local_repo()
         fake_clone_from.assert_called_with('ssh://git@github.com/app/a', temp_dir)
 
     @patch('git.Repo.clone_from')
-    @patch('dusty.source.managed_repo_path')
-    def test_ensure_local_repo_when_repo_exist(self, fake_repo_path, fake_clone_from):
-        fake_repo_path.return_value = self.temp_dir
-        ensure_local_repo('github.com/app/a')
+    def test_ensure_local_repo_when_repo_exist(self, fake_clone_from):
+        self.MockableRepo.managed_path = property(lambda repo: self.temp_dir)
+        self.MockableRepo('github.com/app/a').ensure_local_repo()
         self.assertFalse(fake_clone_from.called)
 
     @patch('git.Repo')
-    @patch('dusty.source.ensure_local_repo')
+    @patch('dusty.source.Repo.ensure_local_repo')
     def test_update_local_repo(self, fake_local_repo, fake_repo):
         repo_mock = Mock()
         pull_mock = Mock()
         repo_mock.remote.return_value = pull_mock
         fake_repo.return_value = repo_mock
-        update_local_repo('github.com/app/a')
+        Repo('github.com/app/a').update_local_repo()
         pull_mock.pull.assert_called_once_with('master')
-
-    @patch('dusty.source.get_all_repos')
-    def test_expand_repo_name_real_name(self, fake_get_repos):
-      fake_get_repos.return_value = set(['github.com/app/a', 'github.com/app/b'])
-      self.assertEquals(_expand_repo_name('a'), 'github.com/app/a')
-
-    @patch('dusty.source.get_all_repos')
-    def test_expand_repo_name_conflict(self, fake_get_repos):
-      fake_get_repos.return_value = set(['github.com/app/a', 'github.com/lib/a'])
-      with self.assertRaises(RuntimeError):
-        _expand_repo_name('a')
-
-    @patch('dusty.source.get_all_repos')
-    def test_expand_repo_name_not_found(self, fake_get_repos):
-      fake_get_repos.return_value = set(['github.com/app/a', 'github.com/lib/b'])
-      with self.assertRaises(RuntimeError):
-        _expand_repo_name('c')


### PR DESCRIPTION
@paetling The various functions for managing Dusty's idea of what a "repo" is were getting out of hand. I've consolidated all of that functionality into a class. This broke basically the entire app.

Plan:
1. Get this massive thing merged and hopefully don't break the entire app
1. Write some tests for the Repo class
1. Usability / consistency improvements around how things are calling this. We have a mix of "passing the repo path" and "passing the Repo object" right now.