### PR TITLE
Kill our fancy checkmarks

### DIFF
--- a/dusty/cli/__init__.py
+++ b/dusty/cli/__init__.py
@@ -24,7 +24,6 @@ Commands:
 For help on a specific command, provide the '-h' flag to the command, e.g. 'dusty repos -h'
 """
 
-import os
 import sys
 import socket
 
@@ -36,11 +35,6 @@ from ..payload import Payload
 from . import (bundles, config, cp, dump, disk, logs, repos, restart, script, shell, stop,
                sync, up, validate, setup, test)
 from .. import constants
-
-# PyInstaller workaround for UTF-8 encoding issues
-# https://github.com/pyinstaller/pyinstaller/issues/1240
-if not os.getenv('PYTHONIOENCODING', None):
-    os.environ['PYTHONIOENCODING'] = 'utf_8'
 
 MODULE_MAP = {
     'bundles': bundles,

--- a/dusty/commands/bundles.py
+++ b/dusty/commands/bundles.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 from prettytable import PrettyTable
 
 from ..config import get_config_value, save_config_value
@@ -13,7 +11,7 @@ def list_bundles():
     for bundle, bundle_spec in specs[constants.CONFIG_BUNDLES_KEY].iteritems():
         table.add_row([bundle,
                        bundle_spec['description'],
-                       u"✓" if bundle in activated_bundles else ""])
+                       "X" if bundle in activated_bundles else ""])
     log_to_client(table.get_string(sortby="Name"))
 
 def activate_bundle(bundle_names):

--- a/dusty/commands/script.py
+++ b/dusty/commands/script.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import textwrap
 from prettytable import PrettyTable
 

--- a/tests/integration/cli/bundles_test.py
+++ b/tests/integration/cli/bundles_test.py
@@ -14,25 +14,25 @@ class TestBundlesCLI(DustyIntegrationTestCase):
     def test_bundles_activate(self):
         self.run_command('bundles activate busybox-a')
         result = self.run_command('bundles list')
-        self.assertInSameLine(result, 'busybox-a', u'X')
-        self.assertNotInSameLine(result, 'busybox-b', u'X')
+        self.assertInSameLine(result, 'busybox-a', 'X')
+        self.assertNotInSameLine(result, 'busybox-b', 'X')
 
     def test_bundles_activate_multiple(self):
         self.run_command('bundles activate busybox-a busybox-b')
         result = self.run_command('bundles list')
-        self.assertInSameLine(result, 'busybox-a', u'X')
-        self.assertInSameLine(result, 'busybox-b', u'X')
+        self.assertInSameLine(result, 'busybox-a', 'X')
+        self.assertInSameLine(result, 'busybox-b', 'X')
 
     def test_bundles_deactivate(self):
         self.run_command('bundles activate busybox-a')
         self.run_command('bundles deactivate busybox-a')
         result = self.run_command('bundles list')
-        self.assertNotInSameLine(result, 'busybox-a', u'X')
-        self.assertNotInSameLine(result, 'busybox-b', u'X')
+        self.assertNotInSameLine(result, 'busybox-a', 'X')
+        self.assertNotInSameLine(result, 'busybox-b', 'X')
 
     def test_bundles_deactivate_multiple(self):
         self.run_command('bundles activate busybox-b')
         self.run_command('bundles deactivate busybox-a busybox-b')
         result = self.run_command('bundles list')
-        self.assertNotInSameLine(result, 'busybox-a', u'X')
-        self.assertNotInSameLine(result, 'busybox-b', u'X')
+        self.assertNotInSameLine(result, 'busybox-a', 'X')
+        self.assertNotInSameLine(result, 'busybox-b', 'X')

--- a/tests/integration/cli/bundles_test.py
+++ b/tests/integration/cli/bundles_test.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 from ...testcases import DustyIntegrationTestCase
 from ...fixtures import busybox_single_app_bundle_fixture
 
@@ -16,25 +14,25 @@ class TestBundlesCLI(DustyIntegrationTestCase):
     def test_bundles_activate(self):
         self.run_command('bundles activate busybox-a')
         result = self.run_command('bundles list')
-        self.assertInSameLine(result, 'busybox-a', u'✓')
-        self.assertNotInSameLine(result, 'busybox-b', u'✓')
+        self.assertInSameLine(result, 'busybox-a', u'X')
+        self.assertNotInSameLine(result, 'busybox-b', u'X')
 
     def test_bundles_activate_multiple(self):
         self.run_command('bundles activate busybox-a busybox-b')
         result = self.run_command('bundles list')
-        self.assertInSameLine(result, 'busybox-a', u'✓')
-        self.assertInSameLine(result, 'busybox-b', u'✓')
+        self.assertInSameLine(result, 'busybox-a', u'X')
+        self.assertInSameLine(result, 'busybox-b', u'X')
 
     def test_bundles_deactivate(self):
         self.run_command('bundles activate busybox-a')
         self.run_command('bundles deactivate busybox-a')
         result = self.run_command('bundles list')
-        self.assertNotInSameLine(result, 'busybox-a', u'✓')
-        self.assertNotInSameLine(result, 'busybox-b', u'✓')
+        self.assertNotInSameLine(result, 'busybox-a', u'X')
+        self.assertNotInSameLine(result, 'busybox-b', u'X')
 
     def test_bundles_deactivate_multiple(self):
         self.run_command('bundles activate busybox-b')
         self.run_command('bundles deactivate busybox-a busybox-b')
         result = self.run_command('bundles list')
-        self.assertNotInSameLine(result, 'busybox-a', u'✓')
-        self.assertNotInSameLine(result, 'busybox-b', u'✓')
+        self.assertNotInSameLine(result, 'busybox-a', u'X')
+        self.assertNotInSameLine(result, 'busybox-b', u'X')

--- a/tests/unit/commands/bundles_test.py
+++ b/tests/unit/commands/bundles_test.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import os
 import tempfile
 import shutil
@@ -17,7 +15,7 @@ class TestBundlesCommands(DustyTestCase):
             output_row = index + 3
             self.assertIn(bundle, result.splitlines()[output_row])
             check_fn = self.assertIn if activated else self.assertNotIn
-            check_fn(u"✓", result.splitlines()[output_row])
+            check_fn(u"X", result.splitlines()[output_row])
 
     def test_list_bundles_with_none_activated(self):
         list_bundles()

--- a/tests/unit/commands/bundles_test.py
+++ b/tests/unit/commands/bundles_test.py
@@ -15,7 +15,7 @@ class TestBundlesCommands(DustyTestCase):
             output_row = index + 3
             self.assertIn(bundle, result.splitlines()[output_row])
             check_fn = self.assertIn if activated else self.assertNotIn
-            check_fn(u"X", result.splitlines()[output_row])
+            check_fn("X", result.splitlines()[output_row])
 
     def test_list_bundles_with_none_activated(self):
         list_bundles()

--- a/tests/unit/commands/repos_test.py
+++ b/tests/unit/commands/repos_test.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import os
 import tempfile
 import shutil


### PR DESCRIPTION
@paetling Default sysout encoding in Python 2 is ASCII, we should stop fighting against that