### PR TITLE
Pull test base image if it doesn't already exist

### DIFF
--- a/tests/unit/systems/docker/testing_images_test.py
+++ b/tests/unit/systems/docker/testing_images_test.py
@@ -58,6 +58,7 @@ class TestTestingImages(DustyTestCase):
         mock_docker_client.create_container.return_value = {'Id': '1'}
         mock_docker_client.commit.return_value = {'Id': '2'}
         image_tag = 'dusty/image'
+        mock_docker_client.images.return_value = [{'RepoTags': [image_tag]}]
         command = 'npm install'
         image_name = 'gcweb_testing_image'
         _make_installed_requirements_image(mock_docker_client, image_tag, command, image_name, [])
@@ -74,6 +75,7 @@ class TestTestingImages(DustyTestCase):
         mock_docker_client.create_container.return_value = {'Id': '1'}
         mock_docker_client.commit.return_value = {'Id': '2'}
         image_tag = 'dusty/image'
+        mock_docker_client.images.return_value = [{'RepoTags': [image_tag]}]
         command = 'npm install'
         image_name = 'gcweb_testing_image'
         _make_installed_requirements_image(mock_docker_client, image_tag, command, image_name, ['os/path:container/path'])


### PR DESCRIPTION
@paetling We need to do this ourselves whenever we're doing stuff directly through the Docker API. When we're using Compose, it has our backs.