### PR TITLE
make sure that boot2docker is running before you run tests

### DIFF
--- a/dusty/commands/test.py
+++ b/dusty/commands/test.py
@@ -10,6 +10,7 @@ from ..systems.docker.testing_image import ensure_test_image, test_image_name
 from ..systems.docker import get_docker_client
 from ..systems.docker.compose import write_composefile, compose_up
 from ..systems.rsync import sync_repos_by_app_name, sync_repos_by_lib_name
+from ..systems.virtualbox import initialize_docker_vm
 from ..log import log_to_client
 
 def test_info_for_app_or_lib(app_or_lib_name):
@@ -27,6 +28,8 @@ def test_info_for_app_or_lib(app_or_lib_name):
     log_to_client(table.get_string(sortby='Test Suite'))
 
 def run_app_or_lib_tests(app_or_lib_name, suite_name, test_arguments, force_recreate=False):
+    log_to_client("Ensuring virtualbox vm is running")
+    initialize_docker_vm()
     client = get_docker_client()
     expanded_specs = get_expanded_libs_specs()
     if app_or_lib_name in expanded_specs['apps']:

--- a/tests/unit/commands/test_test.py
+++ b/tests/unit/commands/test_test.py
@@ -4,7 +4,7 @@ from ...testcases import DustyTestCase
 from ..utils import get_app_dusty_schema, get_lib_dusty_schema
 from dusty.commands import test
 
-
+@patch('dusty.commands.test.initialize_docker_vm')
 @patch('dusty.commands.test.get_docker_client')
 @patch('dusty.commands.test.get_expanded_libs_specs')
 @patch('dusty.commands.test.ensure_test_image')
@@ -20,17 +20,17 @@ class TestTestsCommands(DustyTestCase):
                       'libs': {
                         'lib-a': get_lib_dusty_schema({'test': {'suites': [{'name': 'nose', 'command': 'nosetests lib-a'}]}})}}
 
-    def test_run_app_or_lib_tests_lib_not_found(self, fake_lib_get_volumes, fake_app_get_volumes, fake_repos_by_lib, fake_repos_by_app, fake_ensure_image, fake_expanded_libs, fake_get_docker_client):
+    def test_run_app_or_lib_tests_lib_not_found(self, fake_lib_get_volumes, fake_app_get_volumes, fake_repos_by_lib, fake_repos_by_app, fake_ensure_image, fake_expanded_libs, fake_get_docker_client, fake_initialize_vm):
         fake_expanded_libs.return_value = self.specs
         with self.assertRaises(RuntimeError):
             test.run_app_or_lib_tests('lib-c', '', [])
 
-    def test_run_app_or_lib_tests_app_not_found(self, fake_lib_get_volumes, fake_app_get_volumes, fake_repos_by_lib, fake_repos_by_app, fake_ensure_image, fake_expanded_libs, fake_get_docker_client):
+    def test_run_app_or_lib_tests_app_not_found(self, fake_lib_get_volumes, fake_app_get_volumes, fake_repos_by_lib, fake_repos_by_app, fake_ensure_image, fake_expanded_libs, fake_get_docker_client, fake_initialize_vm):
         fake_expanded_libs.return_value = self.specs
         with self.assertRaises(RuntimeError):
             test.run_app_or_lib_tests('app-c', '', [])
 
-    def test_run_app_or_lib_tests_suite_not_found(self, fake_lib_get_volumes, fake_app_get_volumes, fake_repos_by_lib, fake_repos_by_app, fake_ensure_image, fake_expanded_libs, fake_get_docker_client):
+    def test_run_app_or_lib_tests_suite_not_found(self, fake_lib_get_volumes, fake_app_get_volumes, fake_repos_by_lib, fake_repos_by_app, fake_ensure_image, fake_expanded_libs, fake_get_docker_client, fake_initialize_vm):
         fake_expanded_libs.return_value = self.specs
         with self.assertRaises(RuntimeError):
             test.run_app_or_lib_tests('app-a', 'nosetests', [])
@@ -38,7 +38,7 @@ class TestTestsCommands(DustyTestCase):
     @patch('dusty.commands.test._run_tests_with_image')
     def test_run_app_or_lib_tests_lib_found(self, fake_run_tests, fake_lib_get_volumes, fake_app_get_volumes,
                                             fake_repos_by_lib, fake_repos_by_app, fake_ensure_image,
-                                            fake_expanded_libs, fake_get_docker_client):
+                                            fake_expanded_libs, fake_get_docker_client, fake_initialize_vm):
         fake_expanded_libs.return_value = self.specs
         fake_lib_get_volumes.return_value = ['/host/route:/container/route']
         fake_app_get_volumes.return_value = []
@@ -56,7 +56,7 @@ class TestTestsCommands(DustyTestCase):
     @patch('dusty.commands.test._run_tests_with_image')
     def test_run_app_or_lib_tests_app_found(self, fake_run_tests, fake_lib_get_volumes, fake_app_get_volumes,
                                             fake_repos_by_lib, fake_repos_by_app, fake_ensure_image,
-                                            fake_expanded_libs, fake_get_docker_client):
+                                            fake_expanded_libs, fake_get_docker_client, fake_initialize_vm):
         fake_expanded_libs.return_value = self.specs
         fake_lib_get_volumes.return_value = ['/host/route:/container/route']
         fake_app_get_volumes.return_value = []


### PR DESCRIPTION
review @thieman   I think this should be the one other command other than run that ensures that the vm is running.  This is because it is a totally different flow then up and should be supported independently