### PR TITLE
Make repo and mount optional in app specs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## 0.1.2
+## 0.1.2 (In Progress)
+  * `repo` and `mount` keys in app specs are now optional
 
 ## 0.1.1 (June 18, 2015)
   * BREAKING CHANGE: We have changed the types of some of the values in app, lib, and test schema.  All commands to run in the container are now lists instead of single strings.

--- a/dusty/compiler/compose/__init__.py
+++ b/dusty/compiler/compose/__init__.py
@@ -165,7 +165,9 @@ def get_app_volume_mounts(app_name, assembled_specs):
     and mounts declared in all lib specs the app depends on"""
     app_spec = assembled_specs['apps'][app_name]
     volumes = []
-    volumes.append(_get_app_repo_volume_mount(app_spec))
+    repo_mount = _get_app_repo_volume_mount(app_spec)
+    if repo_mount:
+        volumes.append(repo_mount)
     volumes += _get_app_libs_volume_mounts(app_name, assembled_specs)
     return volumes
 
@@ -180,7 +182,8 @@ def get_lib_volume_mounts(base_lib_name, assembled_specs):
 def _get_app_repo_volume_mount(app_spec):
     """ This returns the formatted volume mount spec to mount the local code for an app in the
     container """
-    return "{}:{}".format(Repo(app_spec['repo']).vm_path, container_code_path(app_spec))
+    if app_spec['repo']:
+        return "{}:{}".format(Repo(app_spec['repo']).vm_path, container_code_path(app_spec))
 
 def _get_lib_repo_volume_mount(lib_spec):
     """ This returns the formatted volume mount spec to mount the local code for a lib in the

--- a/dusty/compiler/spec_assembler.py
+++ b/dusty/compiler/spec_assembler.py
@@ -146,5 +146,6 @@ def get_all_repos(active_only=False, include_specs_repo=True):
         repos.add(get_specs_repo())
     specs = get_assembled_specs() if active_only else get_specs()
     for spec in specs.get_apps_and_libs():
-        repos.add(Repo(spec['repo']))
+        if spec['repo']:
+            repos.add(Repo(spec['repo']))
     return repos

--- a/dusty/schemas/app_schema.py
+++ b/dusty/schemas/app_schema.py
@@ -10,6 +10,16 @@ def image_build_isolation_validator():
             return 'Need to have at least one of `image` or `build` in app schema'
     return validator
 
+def repo_mount_validator():
+    """If either repo or mount are provided, they must both be provided."""
+    def validator(document):
+        if 'repo' in document and 'mount' in document:
+            return
+        elif 'repo' not in document and 'mount' not in document:
+            return
+        return 'If either `repo` or `mount` are provided, they must both be provided.'
+    return validator
+
 app_depends_schema = Schema({
     'services': {'type': Array(basestring), 'default': list},
     'apps': {'type': Array(basestring), 'default': list},
@@ -43,15 +53,18 @@ dusty_app_compose_schema = Schema({
     }, strict=False)
 
 app_schema = Schema({
-    'repo': {'type': basestring, 'required': True},
+    'repo': {'type': basestring, 'default': str},
     'depends': {'type': app_depends_schema, 'default': dict},
     'conditional_links': {'type': conditional_links_schema, 'default': dict},
     'host_forwarding': {'type': Array(host_forwarding_schema), 'default': list},
     'image': {'type': basestring},
     'build': {'type': basestring},
-    'mount': {'type': basestring, 'default': '', 'required': True},
+    'mount': {'type': basestring, 'default': str},
     'commands': {'type': commands_schema, 'default': dict},
     'scripts': {'type': Array(script_schema), 'default': list},
     'compose': {'type': dusty_app_compose_schema, 'default': dict},
     'test': {'type': test_schema, 'default': dict}
-    }, validates=[image_build_isolation_validator()])
+    }, validates=[
+        image_build_isolation_validator(),
+        repo_mount_validator(),
+    ])

--- a/tests/unit/compiler/test_configs/recursive_libs/apps/simpleapp.yml
+++ b/tests/unit/compiler/test_configs/recursive_libs/apps/simpleapp.yml
@@ -1,6 +1,4 @@
-repo: docker.gamechanger.io/simpleapp
 image: docker.gamechanger.io/simpleapp
-mount: /simpleapp
 commands:
   always:
     - run-script.sh

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -6,10 +6,10 @@ from dusty.schemas.bundle_schema import bundle_schema
 def get_app_dusty_schema(doc, name=None):
     if 'image' not in doc and 'build' not in doc:
         doc['image'] = ''
-    if 'repo' not in doc:
-        doc['repo'] = ''
-    if 'mount' not in doc:
-        doc['mount'] = ''
+    if 'repo' in doc and 'mount' not in doc:
+        doc['mount'] = '/repo'
+    if 'mount' in doc and 'repo' not in doc:
+        doc['repo'] = '/repo'
     return DustySchema(app_schema, doc, name, 'apps')
 
 def get_lib_dusty_schema(doc, name=None):


### PR DESCRIPTION
@paetling Ran into a case when creating example specs where I wanted to run a Python fileserver, which is a one-liner requiring no code. https://github.com/gamechanger/example-dusty-specs/blob/master/apps/fileserver.yml