### PR TITLE
dusty up doesnt die if stop fails

### DIFF
--- a/dusty/commands/run.py
+++ b/dusty/commands/run.py
@@ -1,4 +1,5 @@
 import os
+from subprocess import CalledProcessError
 
 from ..compiler import (compose as compose_compiler, nginx as nginx_compiler,
                         port_spec as port_spec_compiler, spec_assembler)
@@ -56,7 +57,11 @@ def stop_apps_or_services(app_or_service_names=None, rm_containers=False):
     else:
         log_to_client("Stopping all running containers associated with Dusty")
 
-    compose.stop_running_services(app_or_service_names)
+    try:
+        compose.stop_running_services(app_or_service_names)
+    except CalledProcessError as e:
+        log_to_client("WARNING: docker-compose stop failed")
+        log_to_client(str(e))
     if rm_containers:
         compose.rm_containers(app_or_service_names)
 

--- a/dusty/commands/run.py
+++ b/dusty/commands/run.py
@@ -24,7 +24,11 @@ def start_local_env(recreate_containers=True, pull_repos=True):
 
     # Stop will fail if we've never written a Composefile before
     if os.path.exists(constants.COMPOSEFILE_PATH):
-        stop_apps_or_services()
+        try:
+            stop_apps_or_services()
+        except CalledProcessError as e:
+            log_to_client("WARNING: docker-compose stop failed")
+            log_to_client(str(e))
     log_to_client("Compiling together the assembled specs")
     if pull_repos:
         update_managed_repos()
@@ -57,11 +61,7 @@ def stop_apps_or_services(app_or_service_names=None, rm_containers=False):
     else:
         log_to_client("Stopping all running containers associated with Dusty")
 
-    try:
-        compose.stop_running_services(app_or_service_names)
-    except CalledProcessError as e:
-        log_to_client("WARNING: docker-compose stop failed")
-        log_to_client(str(e))
+    compose.stop_running_services(app_or_service_names)
     if rm_containers:
         compose.rm_containers(app_or_service_names)
 


### PR DESCRIPTION
@thieman If we write a bad compose file (because of bad specs), currently `dusty up` can't recover, since `docker-compose stop` can fail