### PR TITLE
Take the Payload stuff out of setup

### DIFF
--- a/dusty/cli/setup.py
+++ b/dusty/cli/setup.py
@@ -20,8 +20,6 @@ from ..commands.setup import setup_dusty_config
 
 def main(argv):
     args = docopt(__doc__, argv)
-    payload =  Payload(setup_dusty_config, mac_username=args['--mac_username'],
+    return setup_dusty_config(mac_username=args['--mac_username'],
                               specs_repo=args['--default_specs_repo'],
                               nginx_includes_dir=args['--nginx_includes_dir'])
-    payload.run_on_daemon = False
-    return payload


### PR DESCRIPTION
@jsingle The Payload thing totally broke the setup command. `setup_dusty_config` returns a Payload that needs to be run on the daemon. This flow isn't supported right now when passing local functions through to the client entrypoint for execution. We'd need like a command stack to do that. Which just seems like even more engineering for something that wasn't even a problem before.