### PR TITLE
Js app service lib name unique

### DIFF
--- a/dusty/commands/validate.py
+++ b/dusty/commands/validate.py
@@ -47,6 +47,9 @@ def _check_name_overlap(specs):
     app_lib_overlap = apps.intersection(libs)
     if app_lib_overlap:
         raise ValidationException('Apps and libs cannot share names: {}'.format(app_lib_overlap))
+    service_lib_overlap = services.intersection(libs)
+    if service_lib_overlap:
+        raise ValidationException('Services and libs cannot share names: {}'.format(service_lib_overlap))
 
 def _validate_spec_names(specs):
     _check_name_overlap(specs)

--- a/dusty/commands/validate.py
+++ b/dusty/commands/validate.py
@@ -37,7 +37,19 @@ def _validate_lib_references(lib, specs):
     if not_present:
         raise ValidationException('Libs {} are not present in your specs'.format(', '.join(not_present)))
 
+def _check_name_overlap(specs):
+    apps = set(specs['apps'].keys())
+    libs = set(specs['libs'].keys())
+    services = set(specs['services'].keys())
+    app_service_overlap = apps.intersection(services)
+    if app_service_overlap:
+        raise ValidationException('Apps and services cannot share names: {}'.format(app_service_overlap))
+    app_lib_overlap = apps.intersection(libs)
+    if app_lib_overlap:
+        raise ValidationException('Apps and libs cannot share names: {}'.format(app_lib_overlap))
+
 def _validate_spec_names(specs):
+    _check_name_overlap(specs)
     for app in specs['apps'].values():
         _validate_app_references(app, specs)
     for bundle in specs['bundles'].values():

--- a/tests/unit/commands/validate_test.py
+++ b/tests/unit/commands/validate_test.py
@@ -2,7 +2,8 @@ from schemer import ValidationException
 
 from ...testcases import DustyTestCase
 from ..utils import apply_required_keys
-from dusty.commands.validate import (_validate_app_references, _validate_cycle_free)
+from dusty.commands.validate import (_validate_app_references, _validate_cycle_free,
+                                     _check_name_overlap)
 from dusty import constants
 
 class ValidatorTest(DustyTestCase):
@@ -109,3 +110,34 @@ class ValidatorTest(DustyTestCase):
         specs = self.make_test_specs(specs)
         with self.assertRaises(ValidationException):
             _validate_cycle_free(specs)
+
+    def test_app_lib_unique_detection(self):
+        specs = {'apps': {
+                    'overlap': {
+                    },
+                },
+                'libs': {
+                    'overlap': {
+                    },
+                }
+        }
+        apply_required_keys(specs)
+        specs = self.make_test_specs(specs)
+        with self.assertRaises(ValidationException):
+            _check_name_overlap(specs)
+
+
+    def test_app_service_unique_detection(self):
+        specs = {'apps': {
+                    'overlap': {
+                    },
+                },
+                'services': {
+                    'overlap': {
+                    },
+                }
+        }
+        apply_required_keys(specs)
+        specs = self.make_test_specs(specs)
+        with self.assertRaises(ValidationException):
+            _check_name_overlap(specs)


### PR DESCRIPTION
@thieman add validation to ensure that apps do not share the same name as services or libs