### PR TITLE
Js cleanup named pipes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,8 @@
 ## 0.2.2 (In Progress)
  * NEW: `dusty restart` can now restart stopped containers.
 
+ * FIXED: Containers will no longer block running commands that are backgrounded in the `once` script.
+
 ## 0.2.1 (July 6, 2015)
   * BREAKING CHANGE: `all` is no longer an allowed suite.name in tests.  Setting a suite's name to `all` will cause `dusty validate` to fail.
 

--- a/docs/specs/app-specs.md
+++ b/docs/specs/app-specs.md
@@ -139,7 +139,7 @@ The `always` script must run the application's main process.
 Generally, you will want to do expensive setup operations like installs inside `once`, then start your
 application inside of `always`.
 
-The output of these commands is logged inside the app's container at `/var/log/dusty_always.log` and `/var/log/dusty_once.log`.
+The output of the once command is logged inside the app's container at `/var/log/dusty_once_fn.log`.
 
 ## scripts
 

--- a/dusty/command_file.py
+++ b/dusty/command_file.py
@@ -52,7 +52,7 @@ def _get_always_commands(app_spec):
         commands_with_function.append('dusty_always_fn () {')
         commands_with_function += always_commands
         commands_with_function.append('}')
-        commands_with_function += _tee_output_commands('dusty_always_fn')
+        commands_with_function.append('dusty_always_fn')
     return commands_with_function
 
 def _compile_docker_commands(app_name, assembled_specs):

--- a/dusty/command_file.py
+++ b/dusty/command_file.py
@@ -23,7 +23,7 @@ def _tee_output_commands(command_to_tee):
         'rm -f $PIPEFILE',
         'mkfifo $PIPEFILE',
         '(tee {}.log < $PIPEFILE || true; rm -f $PIPEFILE) &'.format(os.path.join(constants.CONTAINER_LOG_PATH, command_to_tee)),
-        '{} > $PIPEFILE 2>&1'.format(command_to_tee),
+        '{} 2>&1 > $PIPEFILE'.format(command_to_tee),
         '}',
         tee_function_name
     ]

--- a/dusty/command_file.py
+++ b/dusty/command_file.py
@@ -22,11 +22,8 @@ def _tee_output_commands(command_to_tee):
         'PIPEFILE={}_pipe_file'.format(tee_function_name),
         'rm -f $PIPEFILE',
         'mkfifo $PIPEFILE',
-        'tee {}.log < $PIPEFILE &'.format(os.path.join(constants.CONTAINER_LOG_PATH, command_to_tee)),
-        'TEEPID=$!',
+        '(tee {}.log < $PIPEFILE || true; rm -f $PIPEFILE) &'.format(os.path.join(constants.CONTAINER_LOG_PATH, command_to_tee)),
         '{} > $PIPEFILE 2>&1'.format(command_to_tee),
-        'wait $TEEPID',
-        'rm -f $PIPEFILE',
         '}',
         tee_function_name
     ]

--- a/tests/unit/command_file_test.py
+++ b/tests/unit/command_file_test.py
@@ -97,7 +97,7 @@ class TestCommandFile(DustyTestCase):
                      'app1 always 1',
                      'app1 always 2',
                      '}',
-                     ] + command_file._tee_output_commands('dusty_always_fn')
+                     'dusty_always_fn']
         call1 = call(commands1, '{}/app1/dusty_command_file_app1.sh'.format(constants.COMMAND_FILES_DIR))
         commands2 = ['cd /gc/app1',
                      'script1 1',
@@ -238,7 +238,7 @@ class TestCommandFile(DustyTestCase):
             'dusty_always_fn () {',
             'always_script.sh',
             '}',
-        ] + command_file._tee_output_commands('dusty_always_fn')
+            'dusty_always_fn' ]
         actual = command_file._get_always_commands(spec)
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
@paetling PR does:
 * Remove `wait` on pid, which was causing to block on background threads. 
 * Don't send output of `always` to a log file.  I don't think we need to do this since that's the main command that gets run on the container (just use dusty logs)