### PR TITLE
Enable integration tests to run with non-root mac_username

### DIFF
--- a/tests/integration/cli/config_test.py
+++ b/tests/integration/cli/config_test.py
@@ -9,7 +9,7 @@ class TestConfigCLI(DustyIntegrationTestCase):
         result = self.run_command('config list')
         self.assertInSameLine(result, 'Key', 'Description', 'Value')
         self.assertInSameLine(result, 'bundles', '[]')
-        self.assertInSameLine(result, 'mac_username', self.current_user)
+        self.assertInSameLine(result, 'mac_username', self.tests_user)
         self.assertInSameLine(result, 'setup_has_run', 'True')
 
     def test_config_listvalues_returns(self):

--- a/tests/integration/cli/cp_test.py
+++ b/tests/integration/cli/cp_test.py
@@ -9,9 +9,9 @@ class TestCpCLI(DustyIntegrationTestCase):
         super(TestCpCLI, self).setUp()
         busybox_single_app_bundle_fixture(num_bundles=2)
         self.run_command('bundles activate busyboxa busyboxb')
-
         self.file_paths = []
         self.temp_dir = tempfile.mkdtemp()
+        os.chmod(self.temp_dir, 0777)
         for file_num in range(1, 3):
             file_path = os.path.join(self.temp_dir, 'file{}.txt'.format(file_num))
             self.file_paths.append(file_path)

--- a/tests/integration/cli/repos_test.py
+++ b/tests/integration/cli/repos_test.py
@@ -35,9 +35,9 @@ class TestReposCLI(DustyIntegrationTestCase):
     def tearDown(self):
         self.run_command('bundles deactivate busyboxa')
         constants.REPOS_DIR = self.old_repos_dir
-        rmtree(self.fake_override_repo_location)
-        rmtree(self.fake_from_dir)
         rmtree(self.temp_repos_dir)
+        rmtree(self.fake_override_dir)
+        rmtree(self.fake_from_dir)
         super(TestReposCLI, self).tearDown()
 
     def test_repos_list(self):

--- a/tests/integration/cli/repos_test.py
+++ b/tests/integration/cli/repos_test.py
@@ -1,4 +1,4 @@
-from os import path
+import os
 from shutil import rmtree
 from subprocess import check_call
 from tempfile import mkdtemp
@@ -16,13 +16,20 @@ class TestReposCLI(DustyIntegrationTestCase):
         super(TestReposCLI, self).setUp()
         busybox_single_app_bundle_fixture(num_bundles=1)
         self.run_command('bundles activate busyboxa')
+
         self.temp_repos_dir = mkdtemp()
+        self.fake_override_dir = mkdtemp()
+        self.fake_from_dir = mkdtemp()
+
+        os.chmod(self.temp_repos_dir, 0777)
+        os.chmod(self.fake_override_dir, 0777)
+        os.chmod(self.fake_from_dir, 0777)
+
         self.old_repos_dir = constants.REPOS_DIR
         constants.REPOS_DIR = self.temp_repos_dir
-        self.fake_override_repo_location = path.join(mkdtemp(), 'fake-repo')
+        self.fake_override_repo_location = os.path.join(self.fake_override_dir, 'fake-repo')
         self._set_up_fake_local_repo(path=self.fake_override_repo_location)
-        self.fake_from_dir = mkdtemp()
-        self.fake_from_repo_location = path.join(self.fake_from_dir, 'fake-repo')
+        self.fake_from_repo_location = os.path.join(self.fake_from_dir, 'fake-repo')
         self._set_up_fake_local_repo(path=self.fake_from_repo_location)
 
     def tearDown(self):
@@ -62,11 +69,11 @@ class TestReposCLI(DustyIntegrationTestCase):
 
     def test_repos_update(self):
         git_repo = git.Repo(self.fake_override_repo_location)
-        target_file = path.join(self.fake_override_repo_location, 'car')
+        target_file = os.path.join(self.fake_override_repo_location, 'car')
         check_call(['touch', target_file])
-        self.assertFalse(path.isfile(path.join(constants.REPOS_DIR, target_file[1:])))
+        self.assertFalse(os.path.isfile(os.path.join(constants.REPOS_DIR, target_file[1:])))
         self.run_command('repos override fake-repo {}'.format(self.fake_override_repo_location))
         git_repo.index.add([target_file])
         git_repo.index.commit('Second commit')
         self.run_command('repos update')
-        self.assertTrue(path.isfile(path.join(constants.REPOS_DIR, target_file)))
+        self.assertTrue(os.path.isfile(os.path.join(constants.REPOS_DIR, target_file)))

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -89,7 +89,10 @@ class DustyIntegrationTestCase(TestCase):
         write_default_config()
         save_config_value(constants.CONFIG_SETUP_KEY, True)
         save_config_value(constants.CONFIG_SPECS_REPO_KEY, 'github.com/gamechanger/dusty-example-specs')
-        save_config_value(constants.CONFIG_MAC_USERNAME_KEY, self.current_user)
+
+        self.tests_user = os.getenv('DUSTY_INTEGRATION_TESTS_USER', self.current_user)
+        save_config_value(constants.CONFIG_MAC_USERNAME_KEY, self.tests_user)
+
         override_repo(get_specs_repo().remote_path, self.overridden_specs_path)
         self.fake_local_repo_location = '/tmp/fake-repo'
         self._set_up_fake_local_repo('/tmp/fake-repo')


### PR DESCRIPTION
@paetling @jsingle @zacharym Can now provide `DUSTY_INTEGRATION_TESTS_USER` environment var to run with your normal mac_username. Should hopefully eliminate the pain around running integration tests locally. Only necessary change was some permission fudging.