### PR TITLE
Add some standard proxy headers to Nginx location blocks

### DIFF
--- a/dusty/compiler/nginx/__init__.py
+++ b/dusty/compiler/nginx/__init__.py
@@ -1,11 +1,18 @@
 from ...constants import NGINX_MAX_FILE_SIZE
+
 def _nginx_proxy_string(port_spec):
     return "proxy_pass http://{}:{};".format(port_spec['boot2docker_ip'], port_spec['proxied_port'])
 
 def _nginx_location_spec(port_spec):
     """This will output the nginx location config string for speicfic port spec """
     location_string_spec = "\t \t location / { \n"
-    location_string_spec += "\t \t \t {} \n".format(_nginx_proxy_string(port_spec))
+    for location_setting in ['proxy_http_version 1.1;',
+                             'proxy_set_header Upgrade $http_upgrade;',
+                             'proxy_set_header Connection "upgrade";',
+                             'proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;',
+                             'proxy_set_header Host $host;',
+                             _nginx_proxy_string(port_spec)]:
+        location_string_spec += "\t \t \t {} \n".format(location_setting)
     location_string_spec += "\t \t } \n"
     return location_string_spec
 

--- a/tests/unit/compiler/nginx/init_test.py
+++ b/tests/unit/compiler/nginx/init_test.py
@@ -24,6 +24,11 @@ class TestPortSpecCompiler(DustyTestCase):
                 listen 80;
                 server_name local.gc.com;
                 location / {
+                    proxy_http_version 1.1;
+                    proxy_set_header Upgrade $http_upgrade;
+                    proxy_set_header Connection "upgrade";
+                    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header Host $host;
                     proxy_pass http://127.0.0.0:80;
                 }
             }
@@ -39,6 +44,11 @@ class TestPortSpecCompiler(DustyTestCase):
                 listen 8001;
                 server_name local.gcapi.com;
                 location / {
+                    proxy_http_version 1.1;
+                    proxy_set_header Upgrade $http_upgrade;
+                    proxy_set_header Connection "upgrade";
+                    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header Host $host;
                     proxy_pass http://127.0.0.0:8000;
                 }
             }
@@ -63,6 +73,11 @@ class TestPortSpecCompiler(DustyTestCase):
                 listen 8001;
                 server_name local.gcapi.com;
                 location / {
+                    proxy_http_version 1.1;
+                    proxy_set_header Upgrade $http_upgrade;
+                    proxy_set_header Connection "upgrade";
+                    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header Host $host;
                     proxy_pass http://127.0.0.0:8000;
                 }
             }
@@ -71,6 +86,11 @@ class TestPortSpecCompiler(DustyTestCase):
                 listen 80;
                 server_name local.gc.com;
                 location / {
+                    proxy_http_version 1.1;
+                    proxy_set_header Upgrade $http_upgrade;
+                    proxy_set_header Connection "upgrade";
+                    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header Host $host;
                     proxy_pass http://127.0.0.0:80;
                 }
             }


### PR DESCRIPTION
@jsingle Found some issues with running iPython, I think adding these in makes Nginx play a little nicer with its upstreams.