### PR TITLE
Allow dusty upgrade to upgrade to RC if explicitly requested

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0 (In Progress)
  * BREAKING CHANGE: All rsync commands which write data to the VM (sync and disk restore) now remove any files present in the destination directory but not in the source directory. This should make it easier to reason about what is on disk on the VM side of sync. However, files written into source directories at runtime will now be deleted by sync operations.
+ * NEW: `dusty upgrade` can now be used to upgrade to a release candidate
 
 ## 0.2.2 (July 14, 2015)
  * NEW: `dusty repos manage` can now accept an `--all` flag, to have Dusty manage all overridden repos

--- a/dusty/commands/upgrade.py
+++ b/dusty/commands/upgrade.py
@@ -46,6 +46,9 @@ def _test_dusty_binary(binary_path, version):
     except CalledProcessError:
         raise RuntimeError('Downloaded binary is not operating correctly; aborting upgrade')
     test_version = output.split()[-1]
+    if 'RC' in version:
+        log_to_client('Release candidate requested, skipping version check')
+        return
     if test_version != version:
         raise RuntimeError('Version of downloaded binary {} does not match expected {}'.format(test_version, version))
 


### PR DESCRIPTION
@jsingle Based on the rsync branch, should clear up once that gets merged