### PR TITLE
Go back to sourcing rsync from TCL repo

### DIFF
--- a/dusty/systems/virtualbox/__init__.py
+++ b/dusty/systems/virtualbox/__init__.py
@@ -10,11 +10,7 @@ from ...log import log_to_client
 
 def _ensure_rsync_is_installed():
     logging.info('Installing rsync inside the Docker VM')
-    if call_demoted(['boot2docker', 'ssh', 'test -f /lib/ld-linux-x86-64.so.2']) == 0:
-        # rsync 64 bit binary does not exist for tiny core linux. Made our own binary and are pulling and installing that
-        check_and_log_output_and_error_demoted(['boot2docker', 'ssh', 'which rsync || (curl https://64bit-rsync.s3.amazonaws.com/rsync > rsync; sudo chmod 755 rsync; sudo mv rsync /usr/bin/rsync)'])
-    else:
-        check_and_log_output_and_error_demoted(['boot2docker', 'ssh', 'tce-load -wi rsync'])
+    check_and_log_output_and_error_demoted(['boot2docker', 'ssh', 'tce-load -wi rsync'])
 
 def _ensure_persist_dir_is_linked():
     logging.info('Linking {} to VBox disk (if it is not already linked)'.format(constants.VM_PERSIST_DIR))

--- a/dusty/systems/virtualbox/__init__.py
+++ b/dusty/systems/virtualbox/__init__.py
@@ -10,7 +10,11 @@ from ...log import log_to_client
 
 def _ensure_rsync_is_installed():
     logging.info('Installing rsync inside the Docker VM')
-    check_and_log_output_and_error_demoted(['boot2docker', 'ssh', 'tce-load -wi rsync'])
+    # We're running tce-load twice as a hack to get around the fact that, for
+    # completely unknown reasons, tce-load will return with an exit code of 1 after
+    # initial install even if it works just fine. Subsequent install attempts will
+    # be no-ops with a return code of 0.
+    check_and_log_output_and_error_demoted(['boot2docker', 'ssh', 'tce-load -wi rsync || tce-load -wi rsync'])
 
 def _ensure_persist_dir_is_linked():
     logging.info('Linking {} to VBox disk (if it is not already linked)'.format(constants.VM_PERSIST_DIR))


### PR DESCRIPTION
@jsingle rsync has landed in the 64-bit TCL repo, which means we can get rid of our bespoke binary. Hooray! Closes #406.