### PR TITLE
Kill version warnings

### DIFF
--- a/dusty/constants.py
+++ b/dusty/constants.py
@@ -48,13 +48,6 @@ HOSTS_PATH = '/etc/hosts'
 
 VIRTUALBOX_RULE_PREFIX = 'dusty'
 
-SYSTEM_DEPENDENCY_VERSIONS = {
-    'virtualbox': '4.3.26',
-    'boot2docker': '1.7.1',
-    'docker': '1.7.1',
-    'docker-compose': '1.3.1'
-}
-
 CONFIG_BUNDLES_KEY = 'bundles'
 CONFIG_REPO_OVERRIDES_KEY = 'repo_overrides'
 CONFIG_MAC_USERNAME_KEY = 'mac_username'

--- a/dusty/preflight.py
+++ b/dusty/preflight.py
@@ -34,14 +34,6 @@ def _assert_executable_exists(executable_name):
     except subprocess.CalledProcessError, OSError:
         raise PreflightException('Executable not found: {}'.format(executable_name))
 
-def _maybe_version_warning(executable, installed_version):
-    if installed_version != constants.SYSTEM_DEPENDENCY_VERSIONS[executable]:
-        message = 'Your {} version ({}) deviates from the supported version ({}).'.format(executable,
-                                                                                          installed_version,
-                                                                                          constants.SYSTEM_DEPENDENCY_VERSIONS[executable])
-        warnings.warn(message)
-        daemon_warnings.warn('preflight', message)
-
 @returns_exception
 def _check_git():
     _assert_executable_exists('git')
@@ -53,26 +45,18 @@ def _check_rsync():
 @returns_exception
 def _check_virtualbox():
     _assert_executable_exists('VBoxManage')
-    installed_version = subprocess.check_output(['VBoxManage', '-v']).split('r')[0]
-    _maybe_version_warning('virtualbox', installed_version)
 
 @returns_exception
 def _check_boot2docker():
     _assert_executable_exists('boot2docker')
-    installed_version = subprocess.check_output(['boot2docker', 'version']).splitlines()[0].split(':')[1].split('v')[-1]
-    _maybe_version_warning('boot2docker', installed_version)
 
 @returns_exception
 def _check_docker():
     _assert_executable_exists('docker')
-    installed_version = subprocess.check_output(['docker', '-v']).split(',')[0].split(' ')[-1]
-    _maybe_version_warning('docker', installed_version)
 
 @returns_exception
 def _check_docker_compose():
     _assert_executable_exists('docker-compose')
-    installed_version = subprocess.check_output(['docker-compose', '--version']).split('\n')[0].split()[-1].strip()
-    _maybe_version_warning('docker-compose', installed_version)
 
 @returns_exception
 def _assert_hosts_file_is_writable():


### PR DESCRIPTION
@jsingle These were a noble idea, but in practice they alert all the time so people are going to just ignore them. We can easily bring them back if we find a good use for them, e.g. you must have at least X version or Dusty will for sure break.