### PR TITLE
Js volumes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 0.4.0 (In Progress)
+ * BREAKING CHANGE: Dusty now cleans up volumes when removing containers
+
  * NEW: Dusty no longer requires nginx to be installed on your Mac! Dusty now runs a containerized nginx inside Docker instead. All other functionality around host forwarding is unchanged.
  * NEW: Dusty's socket location can now be customized via the `DUSTY_SOCKET_PATH` environment variable
  * NEW: Dusty will use HTTPS to clone public repos which explicitly specify in their URL to use HTTPS

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -115,7 +115,8 @@ Commands:
 ```
 Inspect, cleanup_containers, and cleanup_images are used to manage the disk usage of Dusty's docker
 images and containers.  These can end up taking up a lot of space on boot2docker's virtual disk,
-which is 20G max (dynamically allocated by Virtualbox).
+which is 20G max (dynamically allocated by Virtualbox).  Cleanup_containers uses the `-v` flag with
+`docker rm` to avoid dangling volumes.
 
 Backup and restore are usefull for saving persistent data.  You may want to save the data and
 send it to someone else, or save your data after recreating your boot2docker VM.
@@ -273,6 +274,9 @@ Options:
   --rm  remove containers
 ```
 
+When used with the `--rm` flag, the `-v` flag is passed to `docker-compose rm` to avoid dangling
+volumes.
+
 #### sync
 ```
 Sync repos from the local filesystem to the boot2docker VM.
@@ -336,7 +340,7 @@ that `dusty up` takes are:
  * Pull your Dusty-managed repos
  * Assemble your specs, based on active bundles, into configuration for your hosts file, nginx,
 and Docker Compose
- * Stops running Dusty containers
+ * Stops running Dusty containers, and removes them.  The `-v` flag of `docker-compose rm` is used, to avoid dangling volumes
  * Sync repos from your mac to boot2docker
  * Re-create and launch your docker containers
 

--- a/dusty/commands/run.py
+++ b/dusty/commands/run.py
@@ -32,7 +32,7 @@ def start_local_env(recreate_containers=True, pull_repos=True):
     # Stop will fail if we've never written a Composefile before
     if os.path.exists(constants.COMPOSEFILE_PATH):
         try:
-            stop_apps_or_services()
+            stop_apps_or_services(rm_containers=recreate_containers)
         except CalledProcessError as e:
             log_to_client("WARNING: docker-compose stop failed")
             log_to_client(str(e))

--- a/dusty/commands/test.py
+++ b/dusty/commands/test.py
@@ -160,10 +160,10 @@ def _run_tests_with_image(client, expanded_specs, app_or_lib_name, test_command,
     for line in client.logs(test_container_name, stdout=True, stderr=True, stream=True):
         log_to_client(line.strip())
     exit_code = client.wait(test_container_name)
-    client.remove_container(container=test_container_name)
+    client.remove_container(container=test_container_name, v=True)
 
     for service_container in previous_container_names:
         log_to_client('Killing service container {}'.format(service_container))
         client.kill(service_container)
-        client.remove_container(container=service_container)
+        client.remove_container(container=service_container, v=True)
     return exit_code

--- a/dusty/systems/docker/cleanup.py
+++ b/dusty/systems/docker/cleanup.py
@@ -19,7 +19,7 @@ def remove_exited_dusty_containers():
     for container in exited_containers:
         log_to_client("Removing container {}".format(container['Names'][0]))
         try:
-            client.remove_container(container['Id'])
+            client.remove_container(container['Id'], v=True)
             removed_containers.append(container)
         except Exception as e:
             log_to_client(e.message or str(e))

--- a/dusty/systems/docker/compose.py
+++ b/dusty/systems/docker/compose.py
@@ -45,7 +45,7 @@ def _compose_stop(compose_file_location, project_name, services):
     check_and_log_output_and_error_demoted(command, env=get_docker_env())
 
 def _compose_rm(compose_file_location, project_name, services):
-    command = _compose_base_command(['rm', '-f'], compose_file_location, project_name)
+    command = _compose_base_command(['rm', '-v', '-f'], compose_file_location, project_name)
     if services:
         command += services
     check_and_log_output_and_error_demoted(command, env=get_docker_env())

--- a/tests/integration/cli/up_test.py
+++ b/tests/integration/cli/up_test.py
@@ -18,11 +18,13 @@ class TestUpCLI(DustyIntegrationTestCase):
     def test_basic_up_recreate(self):
         run_output = self.run_command('up')
         run_output = self.run_command('up')
-        self.assertIn('Recreating dusty_busyboxb_1', run_output)
-        self.assertIn('Recreating dusty_busyboxa_1', run_output)
+        self.assertIn('Removing dusty_busyboxb_1', run_output)
+        self.assertIn('Removing dusty_busyboxa_1', run_output)
+        self.assertIn('Creating dusty_busyboxb_1', run_output)
+        self.assertIn('Creating dusty_busyboxa_1', run_output)
         run_output = self.run_command('up --no-recreate')
-        self.assertNotIn('Recreating dusty_busyboxb_1', run_output)
-        self.assertNotIn('Recreating dusty_busyboxa_1', run_output)
+        self.assertNotIn('Creating dusty_busyboxb_1', run_output)
+        self.assertNotIn('Creating dusty_busyboxa_1', run_output)
 
     def test_basic_up_no_pull(self):
         run_output = self.run_command('up')


### PR DESCRIPTION
@thieman I think this adequately fixes https://github.com/gamechanger/dusty/issues/419

Turns out you can pass -v to `docker-compose rm`