### PR TITLE
Js upgrade from rc

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@
  * NEW: Dusty will use HTTPS to clone public repos which explicitly specify in their URL to use HTTPS
  * NEW: `dusty logs` now supports a `-t` option to show timestamps on the logging output
 
+ * FIXED: `dusty upgrade` will now successfully upgrade Dusty from a RC version in all cases
+
  * `dusty status` now shows the status of Dusty's nginx container and has received some performance improvements
 
 ## 0.3.0 (July 24, 2015)

--- a/dusty/commands/upgrade.py
+++ b/dusty/commands/upgrade.py
@@ -74,7 +74,7 @@ def upgrade_dusty_binary(version=None):
         return
     if version is None:
         version = _get_latest_version()
-    if version == constants.VERSION:
+    if not constants.PRERELEASE and version == constants.VERSION:
         log_to_client('You\'re already running the latest Dusty version ({})'.format(version))
         return
     else:

--- a/dusty/constants.py
+++ b/dusty/constants.py
@@ -2,6 +2,7 @@ import os
 
 VERSION = '0.4.0'
 BINARY = False # overridden by PyInstaller when we build a binary
+PRERELEASE = False # overridden by PyInstaller when we build a prerelease binary
 
 EXAMPLE_SPECS_REPO = 'github.com/gamechanger/dusty-example-specs'
 

--- a/setup/binary-hook.py
+++ b/setup/binary-hook.py
@@ -1,2 +1,6 @@
+import os
+
 import dusty.constants
 dusty.constants.BINARY = True
+
+dusty.constants.PRERELEASE = os.getenv('PRERELEASE') == 'true'


### PR DESCRIPTION
@thieman this would allow someone on an RC dusty to upgrade with `dusty upgrade 0.4.0`.  If someone manually enters a version to the upgrade command, it would download & exec no matter what.  If you just type `dusty upgrade`, it would still check if they're already on the latest version.

Fixes https://github.com/gamechanger/dusty/issues/424