### PR TITLE
Force Docker to use our commands, not any defined ENTRYPOINT

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.4.0 (In Progress)
- * BREAKING CHANGE: Dusty now cleans up volumes when removing containers
+ * BREAKING CHANGE: Dusty now removes data volumes when removing containers. Containers needing to persist data should use volume mounts inside of `/persist` in the boot2docker VM.
 
  * NEW: Dusty no longer requires nginx to be installed on your Mac! Dusty now runs a containerized nginx inside Docker instead. All other functionality around host forwarding is unchanged.
  * NEW: Dusty's socket location can now be customized via the `DUSTY_SOCKET_PATH` environment variable
@@ -9,6 +9,7 @@
  * NEW: `dusty logs` now supports a `-t` option to show timestamps on the logging output
 
  * FIXED: `dusty upgrade` will now successfully upgrade Dusty from a RC version in all cases
+ * FIXED: Images with an `ENTRYPOINT` defined now work correctly when used as the basis for a Dusty app
 
  * `dusty status` now shows the status of Dusty's nginx container and has received some performance improvements
 

--- a/docs/specs/app-specs.md
+++ b/docs/specs/app-specs.md
@@ -175,7 +175,9 @@ compose:
 ```
 
 Dusty uses Docker Compose to create and manage containers. The `compose` key allows you to
-override any of the values passed through to Docker Compose at runtime.
+override almost any of the values passed through to Docker Compose at runtime.
+
+Dusty reserves the following keys for itself and specifying them here will have no effect: `COMMAND`, `ENTRYPOINT`
 
 For more information on what you can override through this key, please see
 the [Docker Compose specification](https://docs.docker.com/compose/yml/).

--- a/dusty/compiler/compose/__init__.py
+++ b/dusty/compiler/compose/__init__.py
@@ -98,6 +98,7 @@ def _composed_app_dict(app_name, assembled_specs, port_specs):
         compose_dict['build'] = _get_build_path(app_spec)
     else:
         raise RuntimeError("Neither image nor build was specified in the spec for {}".format(app_name))
+    compose_dict['entrypoint'] = []
     compose_dict['command'] = _compile_docker_command(app_spec)
     logging.info("Compose Compiler: compiled command {}".format(compose_dict['command']))
     compose_dict['links'] = _links_for_app(app_spec, assembled_specs)

--- a/tests/unit/compiler/compose/test.py
+++ b/tests/unit/compiler/compose/test.py
@@ -154,6 +154,7 @@ class TestComposeCompiler(DustyTestCase):
         expected_app_config = {
             'image': 'awesomeGCimage',
             'command': 'what command?',
+            'entrypoint': [],
             'links': [
                 'service1',
                 'service2',


### PR DESCRIPTION
@paetling Fixes #435. I confirmed that @melkorm's Zabbix example works fine with this fix without having the workaround explicitly defined.