### PR TITLE
Js colons fix for volumes

### DIFF
--- a/dusty/config.py
+++ b/dusty/config.py
@@ -47,8 +47,16 @@ def save_config_value(key, value):
         verify_mac_username(value)
         save_config(current_config)
         check_and_load_ssh_auth()
+    elif key == constants.CONFIG_REPO_OVERRIDES_KEY:
+        verify_overrides_without_colons(current_config)
+        save_config(current_config)
     else:
         save_config(current_config)
+
+def verify_overrides_without_colons(current_config):
+    for local_path in current_config[constants.CONFIG_REPO_OVERRIDES_KEY].itervalues():
+        if ':' in local_path:
+            raise RuntimeError('Local repo override path {} contains ":".  Please select a path without a colon'.format(local_path))
 
 def refresh_config_warnings():
     daemon_warnings.clear_namespace('config')

--- a/dusty/source.py
+++ b/dusty/source.py
@@ -75,7 +75,11 @@ class Repo(object):
 
     @property
     def managed_path(self):
-        return os.path.join(constants.REPOS_DIR, self.remote_path.lstrip('/'))
+        local_folder = self.remote_path
+        if ':' in local_folder:
+            local_folder = local_folder.split(':')[1]
+        local_folder = local_folder.lstrip('/')
+        return os.path.join(constants.REPOS_DIR, local_folder)
 
     @property
     def is_overridden(self):

--- a/tests/unit/commands/repos_test.py
+++ b/tests/unit/commands/repos_test.py
@@ -56,6 +56,17 @@ class TestReposCommands(DustyTestCase):
                               {get_specs_repo().remote_path: self.temp_specs_path,
                                'github.com/app/a': self.temp_specs_path})
 
+    def test_override_repo_colon(self):
+        bad_path = os.path.join(self.temp_specs_path, 'colon:path')
+        os.makedirs(bad_path)
+        with self.assertRaises(RuntimeError):
+            override_repo('github.com/app/a', bad_path)
+        list_repos()
+        self._assert_listed_repos(self.last_client_output,
+                                  [['github.com/app/a', False],
+                                   ['github.com/app/b', False]],
+                                  offset=1)
+
     def test_override_then_manage_repo(self):
         override_repo('github.com/app/a', self.temp_specs_path)
         self.assertItemsEqual(get_config_value(constants.CONFIG_REPO_OVERRIDES_KEY),

--- a/tests/unit/source_test.py
+++ b/tests/unit/source_test.py
@@ -55,6 +55,15 @@ class TestSource(DustyTestCase):
         self.assertEqual(Repo('github.com/app/a').managed_path, '/etc/dusty/repos/github.com/app/a')
         self.assertEqual(Repo('/gc/repos/dusty').managed_path, '/etc/dusty/repos/gc/repos/dusty')
 
+    def test_managed_path_http(self):
+        self.assertEqual(Repo('http://github.com/app/a').managed_path, '/etc/dusty/repos/github.com/app/a')
+
+    def test_managed_path_file(self):
+        self.assertEqual(Repo('file:///github.com/app/a').managed_path, '/etc/dusty/repos/github.com/app/a')
+
+    def test_managed_path_ssh(self):
+        self.assertEqual(Repo('ssh://git@github.com/app/a').managed_path, '/etc/dusty/repos/git@github.com/app/a')
+
     def test_override_path(self):
         override_repo('github.com/app/a', self.temp_dir)
         self.assertEqual(Repo('github.com/app/a').override_path, self.temp_dir)


### PR DESCRIPTION
@thieman Docker Compose parses `volumes` by splitting on colons.  Having colons in a local path will mess that up

Fixes https://github.com/gamechanger/dusty/issues/459