### PR TITLE
add reset --hard for dusty up

### DIFF
--- a/dusty/commands/repos.py
+++ b/dusty/commands/repos.py
@@ -58,7 +58,7 @@ def override_repos_from_directory(source_path):
             override_repo(repo.remote_path, repo_path)
 
 @daemon_command
-def update_managed_repos():
+def update_managed_repos(force=False):
     """For any active, managed repos, update the Dusty-managed
     copy to bring it up to date with the latest master."""
     log_to_client('Pulling latest updates for all active managed repos:')
@@ -70,4 +70,4 @@ def update_managed_repos():
     for repo in get_all_repos(active_only=True, include_specs_repo=False):
         if not repo.is_overridden:
             log_to_client('Updating managed copy of {}'.format(repo.remote_path))
-            repo.update_local_repo()
+            repo.update_local_repo(force=force)

--- a/dusty/commands/run.py
+++ b/dusty/commands/run.py
@@ -20,7 +20,7 @@ def start_local_env(recreate_containers=True, pull_repos=True):
     systems will in turn launch the services needed to make the
     local environment go."""
     if pull_repos:
-        update_managed_repos()
+        update_managed_repos(force=True)
     assembled_spec = spec_assembler.get_assembled_specs()
     if not assembled_spec[constants.CONFIG_BUNDLES_KEY]:
         raise RuntimeError('No bundles are activated. Use `dusty bundles` to activate bundles before running `dusty up`.')

--- a/tests/unit/commands/repos_test.py
+++ b/tests/unit/commands/repos_test.py
@@ -96,11 +96,11 @@ class TestReposCommands(DustyTestCase):
     def test_update_managed_repos(self, fake_update_local_repo):
         activate_bundle(['bundle-a'])
         update_managed_repos()
-        fake_update_local_repo.assert_has_calls([call()])
+        fake_update_local_repo.assert_has_calls([call(force=False)])
 
     @patch('dusty.source.Repo.update_local_repo')
     def test_update_managed_repos_for_both(self, fake_update_local_repo):
         activate_bundle(['bundle-a'])
         activate_bundle(['bundle-b'])
         update_managed_repos()
-        fake_update_local_repo.assert_has_calls([call(), call()])
+        fake_update_local_repo.assert_has_calls([call(force=False), call(force=False)])

--- a/tests/unit/source_test.py
+++ b/tests/unit/source_test.py
@@ -146,11 +146,14 @@ class TestSource(DustyTestCase):
         self.assertFalse(fake_clone_from.called)
 
     @patch('git.Repo')
+    @patch('dusty.source.Repo.local_is_up_to_date')
     @patch('dusty.source.Repo.ensure_local_repo')
-    def test_update_local_repo(self, fake_local_repo, fake_repo):
+    def test_update_local_repo(self, fake_local_repo, fake_local_up_to_date, fake_repo):
         repo_mock = Mock()
+        fake_local_up_to_date = Mock()
         pull_mock = Mock()
         repo_mock.remote.return_value = pull_mock
+        fake_local_up_to_date.return_value = True
         fake_repo.return_value = repo_mock
         Repo('github.com/app/a').update_local_repo()
         pull_mock.pull.assert_called_once_with('master')


### PR DESCRIPTION
@thieman this adds `reset --hard origin/master` on dusty up only. In other cases when a repo gets pulled, this would log a warning message to the client