### PR TITLE
dusty status column for env overrides

### DIFF
--- a/dusty/commands/status.py
+++ b/dusty/commands/status.py
@@ -8,11 +8,15 @@ from ..systems.docker import get_dusty_containers
 from ..systems.virtualbox import docker_vm_is_running
 from ..payload import daemon_command
 from .. import constants
+from ..config import get_env_config
 
 def _has_active_container(spec_type, service_name):
     if spec_type == 'lib':
         return False
     return get_dusty_containers([service_name]) != []
+
+def _has_env_override(app_or_service_name):
+    return True if get_env_config().get(app_or_service_name) else False
 
 @daemon_command
 def get_dusty_status():
@@ -20,13 +24,17 @@ def get_dusty_status():
         log_to_client('Docker VM is powered off.  You can start it with `dusty up`')
         return
     assembled_specs = get_assembled_specs()
-    table = PrettyTable(["Name", "Type", "Has Active Container"])
+    table = PrettyTable(["Name", "Type", "Has Active Container", "Env Overridden?"])
     logging.error(assembled_specs._document)
     # Check for Dusty's special nginx container (used for host forwarding)
-    table.add_row([constants.DUSTY_NGINX_NAME, '', 'X' if get_dusty_containers([constants.DUSTY_NGINX_NAME]) != [] else ''])
+    table.add_row([constants.DUSTY_NGINX_NAME, '', 'X' if get_dusty_containers([constants.DUSTY_NGINX_NAME]) != [] else '', ''])
     for spec in assembled_specs.get_apps_libs_and_services():
         spec_type = spec.type_singular
+        if spec_type == 'service' or spec_type == 'app':
+            env_override = _has_env_override(spec.name)
+        else:
+            env_override = False
         service_name = spec.name
         has_activate_container = _has_active_container(spec_type, service_name)
-        table.add_row([service_name, spec_type, 'X' if has_activate_container else ''])
+        table.add_row([service_name, spec_type, 'X' if has_activate_container else '', 'X' if env_override else ''])
     log_to_client(table.get_string(sortby="Type"))

--- a/tests/unit/commands/status_test.py
+++ b/tests/unit/commands/status_test.py
@@ -60,15 +60,16 @@ class TestStatusCommands(DustyTestCase):
         fake_vm_is_running.return_value = True
         get_dusty_status()
         call_args_list = fake_table.add_row.call_args_list
-        self.assertTrue(call(['app1', 'app', 'X']) in call_args_list)
-        self.assertTrue(call(['app2', 'app', 'X']) in call_args_list)
-        self.assertTrue(call(['lib1', 'lib', '']) in call_args_list)
-        self.assertTrue(call(['ser1', 'service', 'X']) in call_args_list)
-        self.assertTrue(call(['ser2', 'service', 'X']) in call_args_list)
-        self.assertTrue(call(['ser3', 'service', 'X']) in call_args_list)
-        self.assertTrue(call(['dustyInternalNginx', '', 'X']) in call_args_list)
+        self.assertTrue(call(['app1', 'app', 'X', '']) in call_args_list)
+        self.assertTrue(call(['app2', 'app', 'X', '']) in call_args_list)
+        self.assertTrue(call(['lib1', 'lib', '', '']) in call_args_list)
+        self.assertTrue(call(['ser1', 'service', 'X', '']) in call_args_list)
+        self.assertTrue(call(['ser2', 'service', 'X', '']) in call_args_list)
+        self.assertTrue(call(['ser3', 'service', 'X', '']) in call_args_list)
+        self.assertTrue(call(['dustyInternalNginx', '', 'X', '']) in call_args_list)
         self.assertEquals(len(call_args_list), 7)
 
+    @patch('dusty.commands.status.get_env_config')
     @patch('dusty.commands.status.docker_vm_is_running')
     @patch('dusty.systems.docker.get_docker_client')
     @patch('dusty.commands.status.PrettyTable')
@@ -78,7 +79,7 @@ class TestStatusCommands(DustyTestCase):
     @patch('dusty.compiler.spec_assembler._get_referenced_libs')
     @patch('dusty.compiler.spec_assembler._get_referenced_services')
     def test_get_dusty_status_active_2(self, fake_get_services, fake_get_libs, fake_get_apps, fake_get_specs,
-                                     fake_get_dusty_containers, fake_pretty_table, fake_get_docker_client, fake_vm_is_running):
+                                     fake_get_dusty_containers, fake_pretty_table, fake_get_docker_client, fake_vm_is_running, fake_get_env_config):
         fake_get_services.return_value = set(['ser1', 'ser2', 'ser3'])
         fake_get_libs.return_value = set(['lib1'])
         fake_get_apps.return_value = set(['app1', 'app2'])
@@ -91,13 +92,18 @@ class TestStatusCommands(DustyTestCase):
                                        'bundles': get_lib_dusty_schema({})}
         fake_get_docker_client.return_value = None
         fake_vm_is_running.return_value = True
+        fake_get_env_config.return_value = {
+            'app1': {},
+            'app2': {'TEST_VAR': 'true'},
+            'ser3': {'TEST_VAR': 'true'}
+        }
         get_dusty_status()
         call_args_list = fake_table.add_row.call_args_list
-        self.assertTrue(call(['app1', 'app', '']) in call_args_list)
-        self.assertTrue(call(['app2', 'app', '']) in call_args_list)
-        self.assertTrue(call(['lib1', 'lib', '']) in call_args_list)
-        self.assertTrue(call(['ser1', 'service', '']) in call_args_list)
-        self.assertTrue(call(['ser2', 'service', '']) in call_args_list)
-        self.assertTrue(call(['ser3', 'service', '']) in call_args_list)
-        self.assertTrue(call(['dustyInternalNginx', '', '']) in call_args_list)
+        self.assertTrue(call(['app1', 'app', '', '']) in call_args_list)
+        self.assertTrue(call(['app2', 'app', '', 'X']) in call_args_list)
+        self.assertTrue(call(['lib1', 'lib', '', '']) in call_args_list)
+        self.assertTrue(call(['ser1', 'service', '', '']) in call_args_list)
+        self.assertTrue(call(['ser2', 'service', '', '']) in call_args_list)
+        self.assertTrue(call(['ser3', 'service', '', 'X']) in call_args_list)
+        self.assertTrue(call(['dustyInternalNginx', '', '', '']) in call_args_list)
         self.assertEquals(len(call_args_list), 7)


### PR DESCRIPTION
@thieman totally forgot to do this too.  You still think it's a good idea?

```
+--------------------+---------+----------------------+-----------------+
|        Name        |   Type  | Has Active Container | Env Overridden? |
+--------------------+---------+----------------------+-----------------+
| dustyInternalNginx |         |          X           |                 |
|      querysh       |   app   |          X           |                 |
|     deferrable     |   lib   |                      |                 |
|     gccontent      |   lib   |                      |                 |
|       gclib        |   lib   |                      |                 |
|    gcstatengine    |   lib   |                      |                 |
| coreElasticSearch  | service |          X           |                 |
|     coreMongo      | service |          X           |                 |
|     coreRedis      | service |          X           |        X        |
+--------------------+---------+----------------------+-----------------+
```