### PR TITLE
save vm_memory as a str

### DIFF
--- a/dusty/commands/setup.py
+++ b/dusty/commands/setup.py
@@ -86,7 +86,7 @@ def setup_dusty_config(mac_username=None, specs_repo=None, vm_memory=None, updat
     else:
         vm_memory = _get_vm_size()
 
-    vm_memory = int(vm_memory)
+    vm_memory = str(vm_memory)
 
     config_dictionary = {constants.CONFIG_MAC_USERNAME_KEY: mac_username,
                          constants.CONFIG_SPECS_REPO_KEY: specs_repo,

--- a/tests/integration/cli/setup_test.py
+++ b/tests/integration/cli/setup_test.py
@@ -20,7 +20,7 @@ class TestSetupCLI(DustyIntegrationTestCase):
         self.run_command('setup --no-update')
         self.assertConfigValue(constants.CONFIG_MAC_USERNAME_KEY, self.current_user)
         self.assertConfigValue(constants.CONFIG_SPECS_REPO_KEY, 'github.com/gamechanger/dusty-example-specs')
-        self.assertConfigValue(constants.CONFIG_VM_MEM_SIZE, 2048)
+        self.assertConfigValue(constants.CONFIG_VM_MEM_SIZE, '2048')
 
     @patch('dusty.commands.setup._get_raw_input')
     def test_setup_override_user(self, fake_raw_input):
@@ -38,10 +38,10 @@ class TestSetupCLI(DustyIntegrationTestCase):
     def test_setup_override_memory(self, fake_raw_input):
         fake_raw_input.side_effect = ['y', '', 'n', '1024']
         self.run_command('setup --no-update')
-        self.assertConfigValue(constants.CONFIG_VM_MEM_SIZE, 1024)
+        self.assertConfigValue(constants.CONFIG_VM_MEM_SIZE, '1024')
 
     def test_setup_flags(self):
         self.run_command('setup --no-update --mac_username={} --default_specs_repo=github.com/gamechanger/dusty-specs --vm_memory=1024'.format(self.current_user))
         self.assertConfigValue(constants.CONFIG_MAC_USERNAME_KEY, self.current_user)
         self.assertConfigValue(constants.CONFIG_SPECS_REPO_KEY, 'github.com/gamechanger/dusty-specs')
-        self.assertConfigValue(constants.CONFIG_VM_MEM_SIZE, 1024)
+        self.assertConfigValue(constants.CONFIG_VM_MEM_SIZE, '1024')

--- a/tests/unit/commands/setup_test.py
+++ b/tests/unit/commands/setup_test.py
@@ -41,7 +41,7 @@ class TestSetupCommands(DustyTestCase):
         fake_get_vm_size.return_value = 6
         expected_dict_argument = {constants.CONFIG_MAC_USERNAME_KEY: 'user',
                                   constants.CONFIG_SPECS_REPO_KEY: 'github.com/gamechanger/dusty',
-                                  constants.CONFIG_VM_MEM_SIZE: 6}
+                                  constants.CONFIG_VM_MEM_SIZE: '6'}
         return_payload = setup_dusty_config()
         self.assertEqual(return_payload.fn, complete_setup)
         self.assertEqual(return_payload.args[0], expected_dict_argument)


### PR DESCRIPTION
@jsingle I think this takes care of it. Do you know why we would have this cast as an int originally?