### PR TITLE
always get new environment per client request

### DIFF
--- a/dusty/systems/docker/__init__.py
+++ b/dusty/systems/docker/__init__.py
@@ -26,23 +26,16 @@ def get_dusty_images():
 def get_dusty_container_name(service_name):
     return 'dusty_{}_1'.format(service_name)
 
-def _get_set_envs():
-    env = {}
-    for key in ('DOCKER_HOST', 'DOCKER_CERT_PATH', 'DOCKER_TLS_VERIFY'):
-        if key in os.environ:
-            env[key] = os.environ[key]
-    return env
-
+@memoized
 def get_docker_env():
-    env = _get_set_envs()
-    if len(env.keys()) < 3:
-        output = check_output_demoted(['docker-machine', 'env', constants.VM_MACHINE_NAME], redirect_stderr=True)
-        for line in output.splitlines():
-            if not line.strip().startswith('export'):
-                continue
-            k, v = line.strip().split()[1].split('=')
-            v = v.replace('"', '')
-            env[k] = v
+    env = {}
+    output = check_output_demoted(['docker-machine', 'env', constants.VM_MACHINE_NAME], redirect_stderr=True)
+    for line in output.splitlines():
+        if not line.strip().startswith('export'):
+            continue
+        k, v = line.strip().split()[1].split('=')
+        v = v.replace('"', '')
+        env[k] = v
     return env
 
 @memoized

--- a/tests/unit/systems/docker/init_test.py
+++ b/tests/unit/systems/docker/init_test.py
@@ -57,23 +57,10 @@ class TestComposeSystem(DustyTestCase):
 
     @patch('dusty.subprocess.get_config_value')
     @patch('dusty.systems.docker.check_output_demoted')
-    @patch.dict('dusty.systems.docker.os.environ', {'DOCKER_TLS_VERIFY': '1',
-                                                    'DOCKER_HOST': 'tcp://192.168.59.103:2376',
-                                                    'DOCKER_CERT_PATH': '/Users/root/.docker/machine/machines/dusty/cert.pem'})
-    def test_get_docker_env_2(self, fake_check_output, fake_config_value):
-        fake_config_value.return_value = 'root'
-        fake_check_output.return_value = """Variables are already set"""
-        expected = {'DOCKER_TLS_VERIFY': '1',
-                    'DOCKER_HOST': 'tcp://192.168.59.103:2376',
-                    'DOCKER_CERT_PATH': '/Users/root/.docker/machine/machines/dusty/cert.pem'}
-        result = get_docker_env()
-        self.assertItemsEqual(result, expected)
-
-    @patch('dusty.subprocess.get_config_value')
-    @patch('dusty.systems.docker.check_output_demoted')
     @patch('dusty.systems.docker.os.environ', {'DOCKER_TLS_VERIFY': '2',
-                                               'DOCKER_HOST': 'tcp://192.168.59.103:2375'})
-    def test_get_docker_env_3(self, fake_check_output, fake_config_value):
+                                               'DOCKER_HOST': 'tcp://192.168.59.103:2375',
+                                               'DOCKER_CERT_PATH': 'baaaaaad'})
+    def test_get_docker_env_2(self, fake_check_output, fake_config_value):
         fake_config_value.return_value = 'root'
         fake_check_output.return_value = """    export DOCKER_TLS_VERIFY=1
         export DOCKER_HOST=tcp://192.168.59.103:2376


### PR DESCRIPTION
@paetling I think we were just doing this before because `boot2docker shellinit` wouldn't give us variables back if they're already set.  This isn't the case in docker-machine, and it's actually messing people up in some cases