### PR TITLE
cast config value to string

### DIFF
--- a/dusty/systems/virtualbox/__init__.py
+++ b/dusty/systems/virtualbox/__init__.py
@@ -63,7 +63,7 @@ def _init_docker_vm():
         logging.info('Initializing new Dusty VM with Docker Machine')
         machine_options = ['--driver', 'virtualbox',
                            '--virtualbox-cpu-count', '-1',
-                           '--virtualbox-memory', get_config_value(constants.CONFIG_VM_MEM_SIZE)]
+                           '--virtualbox-memory', str(get_config_value(constants.CONFIG_VM_MEM_SIZE))]
         check_call_demoted(['docker-machine', 'create'] + machine_options + [constants.VM_MACHINE_NAME],
                            redirect_stderr=True)
 


### PR DESCRIPTION
@zacharym remember how you wanted to do this at one point?  Turns out we still have to do it even after we fixed where we're writing the value.  Some people already have the value written as an int, so it needs to be fixed on the read side too :(