### PR TITLE
Dependency fixes for integration tests

### DIFF
--- a/dusty/command_file.py
+++ b/dusty/command_file.py
@@ -42,7 +42,7 @@ def _tee_output_commands(command_to_tee):
 def _hosts_export_commands(port_spec):
     if not port_spec['hosts_file']:
         return []
-    commands = ['DOCKERHOST=`/sbin/ip route|awk \'/default/ { print $3 }\'`']
+    commands = ['DOCKERHOST=`ip route|awk \'/default/ { print $3 }\'`']
     commands.extend(['echo "$DOCKERHOST    {}" >> /etc/hosts'.format(host['host_address'])
         for host in port_spec['hosts_file']])
     return commands

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -40,7 +40,7 @@ def _write(spec_type, name, spec_doc):
     if 'repo' in spec_doc:
         repo = Repo(spec_doc['repo'])
         if repo.is_local_repo:
-            set_up_fake_local_repo(repo.local_path)
+            set_up_fake_local_repo('/{}'.format(repo.rel_path))
 
 def premade_app():
     return DustySchema(app_schema, {'repo': '/tmp/fake-repo',
@@ -120,7 +120,7 @@ def basic_specs_fixture():
                             'scripts': [{'description': 'A script description',
                                         'command': ['ls /'],
                                         'name': 'example'}]})
-    _write('app', 'app-c', {'repo': '/gc/repos/c',
+    _write('app', 'app-c', {'repo': '/tmp/repo-c',
                             'commands': {
                                 'always': ['sleep 10']
                             },

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,6 +4,9 @@ from mock import patch
 import os
 import yaml
 
+import git
+
+from dusty.source import Repo
 from dusty.compiler.spec_assembler import get_specs_path
 from dusty.schemas.base_schema_class import DustySchema, DustySpecs
 from dusty.schemas.app_schema import app_schema
@@ -13,17 +16,31 @@ def _num_to_alpha(num):
         raise ValueError('Only supports up to 26')
     return chr(num + 97)
 
+def set_up_fake_local_repo(path='/tmp/fake-repo'):
+    repo = git.Repo.init(path)
+    with open(os.path.join(path, 'README.md'), 'w') as f:
+        f.write('# {}'.format(path.split('/')[-1]))
+    repo.index.add([os.path.join(path, 'README.md')])
+    repo.index.commit('Initial commit')
+
 def _write(spec_type, name, spec_doc):
     spec_type_path = os.path.join(get_specs_path(), '{}s'.format(spec_type))
+
     try:
         os.makedirs(spec_type_path)
     except OSError:
         pass
+
     spec_path = os.path.join(spec_type_path, '{}.yml'.format(name))
     if os.path.exists(spec_path):
         os.remove(spec_path)
     with open(spec_path, 'w') as f:
         f.write(yaml.safe_dump(spec_doc, default_flow_style=False))
+
+    if 'repo' in spec_doc:
+        repo = Repo(spec_doc['repo'])
+        if repo.is_local_repo:
+            set_up_fake_local_repo(repo.local_path)
 
 def premade_app():
     return DustySchema(app_schema, {'repo': '/tmp/fake-repo',

--- a/tests/integration/cli/repos_test.py
+++ b/tests/integration/cli/repos_test.py
@@ -15,6 +15,7 @@ class TestReposCLI(DustyIntegrationTestCase):
     def setUp(self):
         super(TestReposCLI, self).setUp()
         busybox_single_app_bundle_fixture(num_bundles=1)
+        single_specs_fixture()
 
         self.temp_repos_dir = mkdtemp()
         self.fake_override_dir = mkdtemp()
@@ -30,7 +31,6 @@ class TestReposCLI(DustyIntegrationTestCase):
         self._set_up_fake_local_repo(path=self.fake_from_repo_location)
         self.fake_source_repo_location = '/tmp/fake-repo'
         self._set_up_fake_local_repo(path=self.fake_source_repo_location)
-        single_specs_fixture()
 
     def tearDown(self):
         rmtree(self.temp_repos_dir)

--- a/tests/integration/command_file_test.py
+++ b/tests/integration/command_file_test.py
@@ -87,6 +87,6 @@ class TestCommandFile(DustyIntegrationTestCase):
         self.run_command('bundles activate bundle-b')
         self.run_command('up --no-pull')
         hosts_contents = self.exec_in_container('appa', 'cat /etc/hosts')
-        ip_route = self.exec_in_container('appa', '/sbin/ip route')
+        ip_route = self.exec_in_container('appa', 'ip route')
         dockerhost = filter(lambda line: 'default' in line, ip_route.splitlines())[0].split()[2]
         self.assertInSameLine(hosts_contents, 'local.appc.com', dockerhost)

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -14,7 +14,6 @@ from contextlib import contextmanager
 from unittest import TestCase
 from nose.tools import nottest
 from mock import patch
-import git
 
 from dusty import constants
 from dusty.config import write_default_config, save_config_value, get_config, save_config
@@ -27,7 +26,7 @@ from dusty.systems.nfs import client as nfs_client
 from dusty.systems.nfs import server as nfs_server
 from dusty.path import parent_dir
 from dusty.subprocess import call_demoted
-from .fixtures import basic_specs_fixture
+from .fixtures import basic_specs_fixture, set_up_fake_local_repo
 from dusty.log import client_logger, DustyClientTestingSocketHandler
 from dusty.memoize import reset_memoize_cache
 
@@ -192,11 +191,7 @@ class DustyIntegrationTestCase(TestCase):
             raise RuntimeError('Exec docker processes didn\'t complete before timeout of {}s'.format(timeout))
 
     def _set_up_fake_local_repo(self, path='/tmp/fake-repo'):
-        repo = git.Repo.init(path)
-        with open(os.path.join(path, 'README.md'), 'w') as f:
-            f.write('# {}'.format(path.split('/')[-1]))
-        repo.index.add([os.path.join(path, 'README.md')])
-        repo.index.commit('Initial commit')
+        set_up_fake_local_repo(path)
 
     def _in_same_line(self, string, *values):
         for line in string.splitlines():

--- a/tests/unit/command_file_test.py
+++ b/tests/unit/command_file_test.py
@@ -271,7 +271,7 @@ class TestCommandFile(DustyTestCase):
         port_spec = {'hosts_file': [{'host_address': 'local.something.com'}]}
         expected = [
             'dusty_once_fn () {',
-            'DOCKERHOST=`/sbin/ip route|awk \'/default/ { print $3 }\'`',
+            'DOCKERHOST=`ip route|awk \'/default/ { print $3 }\'`',
             'echo "$DOCKERHOST    local.something.com" >> /etc/hosts',
             '}',
             'if [ ! -f {} ]; then'.format(constants.FIRST_RUN_FILE_PATH),

--- a/tests/unit/source_test.py
+++ b/tests/unit/source_test.py
@@ -84,8 +84,8 @@ class TestSource(DustyTestCase):
     def test_override_path(self):
         override_repo('github.com/app/a', self.temp_dir)
         self.assertEqual(Repo('github.com/app/a').override_path, self.temp_dir)
-        override_repo('/gc/repos/c', self.temp_dir)
-        self.assertEqual(Repo('/gc/repos/c').override_path, self.temp_dir)
+        override_repo('/tmp/repo-c', self.temp_dir)
+        self.assertEqual(Repo('/tmp/repo-c').override_path, self.temp_dir)
 
     def test_local_path(self):
         repo = Repo('github.com/app/a')
@@ -95,7 +95,7 @@ class TestSource(DustyTestCase):
 
     def test_vm_path(self):
         self.assertEqual(Repo('github.com/app/a').vm_path, '/dusty_repos/github.com/app/a')
-        self.assertEqual(Repo('/gc/repos/c').vm_path, '/dusty_repos/gc/repos/c')
+        self.assertEqual(Repo('/tmp/repo-c').vm_path, '/dusty_repos/tmp/repo-c')
 
     def test_repo_is_overridden_true(self):
         override_repo('github.com/app/a', self.temp_dir)
@@ -125,15 +125,15 @@ class TestSource(DustyTestCase):
     def test_ensure_local_repo_when_does_not_exist_with_local_remote(self, fake_clone_from):
         temp_dir = os.path.join(self.temp_dir, 'c')
         self.MockableRepo.managed_path = property(lambda repo: temp_dir)
-        self.MockableRepo('/gc/repos/c').ensure_local_repo()
-        fake_clone_from.assert_called_with('file:////gc/repos/c', temp_dir)
+        self.MockableRepo('/tmp/repo-c').ensure_local_repo()
+        fake_clone_from.assert_called_with('file:////tmp/repo-c', temp_dir)
 
     @patch('git.Repo.clone_from')
     def test_ensure_local_repo_when_does_not_exist_with_https_remote(self, fake_clone_from):
         temp_dir = os.path.join(self.temp_dir, 'd')
         self.MockableRepo.managed_path = property(lambda repo: temp_dir)
-        self.MockableRepo('https://gc/repos/c.git').ensure_local_repo()
-        fake_clone_from.assert_called_with('https://gc/repos/c.git', temp_dir)
+        self.MockableRepo('https://tmp/repo-c.git').ensure_local_repo()
+        fake_clone_from.assert_called_with('https://tmp/repo-c.git', temp_dir)
 
     @patch('git.Repo.clone_from')
     def test_ensure_accepts_ssh_prefix_remote_path(self, fake_clone_from):
@@ -146,15 +146,15 @@ class TestSource(DustyTestCase):
     def test_ensure_accepts_file_prefix_remote_path(self, fake_clone_from):
         temp_dir = os.path.join(self.temp_dir, 'd')
         self.MockableRepo.managed_path = property(lambda repo: temp_dir)
-        self.MockableRepo('file:///gc/repos/c.git').ensure_local_repo()
-        fake_clone_from.assert_called_with('file:///gc/repos/c.git', temp_dir)
+        self.MockableRepo('file:///tmp/repo-c.git').ensure_local_repo()
+        fake_clone_from.assert_called_with('file:///tmp/repo-c.git', temp_dir)
 
     @patch('git.Repo.clone_from')
-    def test_ensure_accpets_without_git_suffix(self, fake_clone_from):
+    def test_ensure_accepts_without_git_suffix(self, fake_clone_from):
         temp_dir = os.path.join(self.temp_dir, 'd')
         self.MockableRepo.managed_path = property(lambda repo: temp_dir)
-        self.MockableRepo('https://gc/repos/c').ensure_local_repo()
-        fake_clone_from.assert_called_with('https://gc/repos/c.git', temp_dir)
+        self.MockableRepo('https://tmp/repo-c').ensure_local_repo()
+        fake_clone_from.assert_called_with('https://tmp/repo-c.git', temp_dir)
 
     @patch('git.Repo.clone_from')
     def test_ensure_local_repo_when_repo_exist(self, fake_clone_from):

--- a/tmp/fake-repo/README.md
+++ b/tmp/fake-repo/README.md
@@ -1,0 +1,1 @@
+# fake-repo

--- a/tmp/fake-repo/README.md
+++ b/tmp/fake-repo/README.md
@@ -1,1 +1,0 @@
-# fake-repo


### PR DESCRIPTION
@jsingle Also makes the usage of `ip` for Dockerhost discovery more flexible (will search through the PATH instead of always looking in /sbin)