### PR TITLE
Removed hardcoded git user and protocol

### DIFF
--- a/dusty/constants.py
+++ b/dusty/constants.py
@@ -94,8 +94,6 @@ CONTAINER_CP_DIR = '/cp'
 VM_COMMAND_FILES_DIR = '/command_files'
 CONTAINER_COMMAND_FILES_DIR = '/command_files'
 
-GIT_USER = 'git'
-
 HOSTS_PATH = '/etc/hosts'
 EXPORTS_PATH = '/etc/exports'
 

--- a/dusty/source.py
+++ b/dusty/source.py
@@ -118,10 +118,7 @@ class Repo(object):
             else:
                 return self.remote_path + '.git'
         else:
-            if self.remote_path.startswith('ssh://'):
-                return self.remote_path
-            else:
-                return 'ssh://{}@{}'.format(constants.GIT_USER, self.remote_path)
+            return self.remote_path
 
     def ensure_local_repo(self):
         """Given a Dusty repo object, clone the remote into Dusty's local repos

--- a/tests/unit/source_test.py
+++ b/tests/unit/source_test.py
@@ -118,8 +118,8 @@ class TestSource(DustyTestCase):
     def test_ensure_local_repo_when_does_not_exist(self, fake_clone_from):
         temp_dir = os.path.join(self.temp_dir, 'a')
         self.MockableRepo.managed_path = property(lambda repo: temp_dir)
-        self.MockableRepo('github.com/app/a').ensure_local_repo()
-        fake_clone_from.assert_called_with('ssh://git@github.com/app/a', temp_dir)
+        self.MockableRepo('git@github.com/app/a').ensure_local_repo()
+        fake_clone_from.assert_called_with('git@github.com/app/a', temp_dir)
 
     @patch('git.Repo.clone_from')
     def test_ensure_local_repo_when_does_not_exist_with_local_remote(self, fake_clone_from):


### PR DESCRIPTION
1. Git user should not be hardcoded
2. ssh:// prefix that added inside code doesn't needed in most of cases. Moreover - ssh:// prefix are not supported by some git provider such as bitbucket.
- Let user configure git connection completely