### PR TITLE
Js docker machine env fix

### DIFF
--- a/dusty/systems/docker/__init__.py
+++ b/dusty/systems/docker/__init__.py
@@ -29,7 +29,7 @@ def get_dusty_container_name(service_name):
 @memoized
 def get_docker_env():
     env = {}
-    output = check_output_demoted(['docker-machine', 'env', constants.VM_MACHINE_NAME], redirect_stderr=True)
+    output = check_output_demoted(['docker-machine', 'env', constants.VM_MACHINE_NAME, '--shell', 'bash'], redirect_stderr=True)
     for line in output.splitlines():
         if not line.strip().startswith('export'):
             continue


### PR DESCRIPTION
@thieman @paetling  I think the default should be to pass the current environment to the subprocess, I'm not sure why we're not already doing that

Also for reasons I haven't investigated, `docker-machine env` now wants the `--shell` flag passed to it

Fixes #611 