### PR TITLE
Sort by short name not Full Name

### DIFF
--- a/dusty/commands/repos.py
+++ b/dusty/commands/repos.py
@@ -19,7 +19,7 @@ def list_repos():
     for repo in repos:
         table.add_row([repo.remote_path, repo.short_name,
                        repo.override_path if repo.is_overridden else ''])
-    log_to_client(table.get_string(sortby='Full Name'))
+    log_to_client(table.get_string(sortby='Short Name'))
 
 @daemon_command
 def override_repo(repo_name, source_path):

--- a/tests/unit/commands/repos_test.py
+++ b/tests/unit/commands/repos_test.py
@@ -28,26 +28,29 @@ class TestReposCommands(DustyTestCase):
     def test_list_repos_with_no_overrides(self):
         list_repos()
         self._assert_listed_repos(self.last_client_output,
-                                  [['github.com/app/a', False],
-                                   ['github.com/app/b', False]],
-                                  offset=1)
+                                  [['github.com/app/a', False]])
+        self._assert_listed_repos(self.last_client_output,
+                                  [['github.com/app/b', False]],
+                                  offset=2)
 
     def test_list_repos_with_one_override(self):
         override_repo('github.com/app/a', self.temp_specs_path)
         list_repos()
         self._assert_listed_repos(self.last_client_output,
-                                  [['github.com/app/a', self.temp_specs_path],
-                                   ['github.com/app/b', False]],
-                                  offset=1)
+                                  [['github.com/app/a', self.temp_specs_path]])
+        self._assert_listed_repos(self.last_client_output,
+                                  [['github.com/app/b', False]],
+                                  offset=2)
 
     def test_list_repos_with_both_overridden(self):
         override_repo('github.com/app/a', self.temp_specs_path)
         override_repo('github.com/app/b', self.temp_specs_path)
         list_repos()
         self._assert_listed_repos(self.last_client_output,
-                                  [['github.com/app/a', self.temp_specs_path],
-                                   ['github.com/app/b', self.temp_specs_path]],
-                                  offset=1)
+                                  [['github.com/app/a', self.temp_specs_path]])
+        self._assert_listed_repos(self.last_client_output,
+                                  [['github.com/app/b', self.temp_specs_path]],
+                                  offset=2)
 
     def test_override_repo(self):
         override_repo('github.com/app/a', self.temp_specs_path)
@@ -62,9 +65,10 @@ class TestReposCommands(DustyTestCase):
             override_repo('github.com/app/a', bad_path)
         list_repos()
         self._assert_listed_repos(self.last_client_output,
-                                  [['github.com/app/a', False],
-                                   ['github.com/app/b', False]],
-                                  offset=1)
+                                  [['github.com/app/a', False]])
+        self._assert_listed_repos(self.last_client_output,
+                                  [['github.com/app/b', False]],
+                                  offset=2)
 
     def test_override_then_manage_repo(self):
         override_repo('github.com/app/a', self.temp_specs_path)


### PR DESCRIPTION
review @thieman   Sorting by Full Name gave nonintuive ordering when I changed to use multiple ways of specifying repo urls: 
![image](https://cloud.githubusercontent.com/assets/3281726/12929086/f89463d8-cf3e-11e5-9e54-4dac7c00820f.png)
