### PR TITLE
Raise on no bridge IP from VBox

### DIFF
--- a/dusty/systems/virtualbox/__init__.py
+++ b/dusty/systems/virtualbox/__init__.py
@@ -119,8 +119,11 @@ def get_docker_vm_ip():
 
 @memoized
 def get_docker_bridge_ip():
-    return check_output_demoted(['docker-machine', 'ssh', constants.VM_MACHINE_NAME,
-                                 "ip route | grep docker0 | awk '{print $NF}'"]).rstrip()
+    result = check_output_demoted(['docker-machine', 'ssh', constants.VM_MACHINE_NAME,
+                                   "ip route | grep docker0 | awk '{print $NF}'"]).rstrip()
+    if not result:
+        raise ValueError('Could not get Docker bridge IP from Virtualbox, VM may not be fully initialized')
+    return result
 
 def _parse_df_output(df_line):
     split_line = df_line.split()


### PR DESCRIPTION
@paetling I just ran a `dusty up` from a powered-down VM and many of my containers failed during startup, including my internal `nginx` container. I'm still trying to track down everything that happened but one of the issues was that it couldn't grab the bridge IP, which resulted in the nginx config being malformed. I suspect this is a symptom of the `docker` daemon not being fully initialized, which may have explained the other problems as well. Going to keep digging in for other fixes.