### PR TITLE
Remove restriction on one forwarding rule per container port

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 * **Misc**
     * Added support of Docker Compose 1.6
     * `dusty disk restore` now appends the `dusty-backup` suffix to the restore path if not provided, which should make the `restore` command a bit more intuitive to use
+    * Host forwarding now supports multiple forwarding rules per app to the same container port for HTTP forwarding
 
 ## 0.6.5 (January 13, 2016)
 

--- a/dusty/compiler/port_spec/__init__.py
+++ b/dusty/compiler/port_spec/__init__.py
@@ -1,9 +1,6 @@
 class ReusedHostFullAddress(Exception):
     pass
 
-class ReusedContainerPort(Exception):
-    pass
-
 class ReusedStreamHostPort(Exception):
     pass
 
@@ -26,12 +23,6 @@ def _add_full_addresses(host_forwarding_spec, host_full_addresses):
     if host_full_address in host_full_addresses:
         raise ReusedHostFullAddress("{} has already been specified and used".format(host_full_address))
     host_full_addresses.add(host_full_address)
-
-def _add_container_ports(host_forwarding_spec, container_ports):
-    container_port = host_forwarding_spec['container_port']
-    if container_port in container_ports:
-        raise ReusedContainerPort("{} has already been specified and used".format(container_port))
-    container_ports.add(container_port)
 
 def _add_stream_host_port(host_forwarding_spec, stream_host_ports):
     stream_host_port = host_forwarding_spec['host_port']
@@ -59,11 +50,9 @@ def get_port_spec_document(expanded_active_specs, docker_vm_ip):
         if 'host_forwarding' not in app_spec:
             continue
         port_spec['docker_compose'][app_name] = []
-        container_ports = set()
         for host_forwarding_spec in app_spec['host_forwarding']:
             # These functions are just used for validating the set of specs all works together
             _add_full_addresses(host_forwarding_spec, host_full_addresses)
-            _add_container_ports(host_forwarding_spec, container_ports)
             if host_forwarding_spec['type'] == 'stream':
                 _add_stream_host_port(host_forwarding_spec, stream_host_ports)
 

--- a/tests/unit/compiler/port_spec/init_test.py
+++ b/tests/unit/compiler/port_spec/init_test.py
@@ -3,8 +3,7 @@ from mock import patch
 from ....testcases import DustyTestCase
 from dusty.compiler.port_spec import (_docker_compose_port_spec, _nginx_port_spec,
                                       _hosts_file_port_spec, get_port_spec_document,
-                                      ReusedHostFullAddress, ReusedContainerPort,
-                                      ReusedStreamHostPort)
+                                      ReusedHostFullAddress, ReusedStreamHostPort)
 
 class TestPortSpecCompiler(DustyTestCase):
     def setUp(self):
@@ -153,25 +152,6 @@ class TestPortSpecCompiler(DustyTestCase):
                                                               'container_port': 81,
                                                               'type': 'http'}]}}}
         with self.assertRaises(ReusedHostFullAddress):
-            get_port_spec_document(expanded_spec, '192.168.5.10')
-
-    def test_port_spec_throws_container_port(self):
-        expanded_spec = {'apps':
-                                {'gcweb':
-                                         {'host_forwarding':[{'host_name': 'local.gc.com',
-                                                              'host_port': 80,
-                                                              'container_port': 80,
-                                                              'type': 'http'},
-                                                             {'host_name': 'local.gc.com',
-                                                             'host_port': 81,
-                                                              'container_port': 80,
-                                                              'type': 'http'}]},
-                                 'gcapi':
-                                         {'host_forwarding':[{'host_name': 'local.gc.com',
-                                                              'host_port': 82,
-                                                              'container_port': 81,
-                                                              'type': 'http'}]}}}
-        with self.assertRaises(ReusedContainerPort):
             get_port_spec_document(expanded_spec, '192.168.5.10')
 
     def test_port_spec_throws_stream_host_port(self):


### PR DESCRIPTION
@paetling Closes #607. I think this restriction was a relic of the early builds when we ran `nginx` on the Mac side. It works perfectly fine without these checks in place now.