### PR TITLE
Ae easier urls

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 * **New**
     * Added `--only` flag to `bundles activate` which makes it easier to turn on a selection of bundles and deactivate all others
-    * Added support for SCP style GitHub urls as seen on github. Example: git@github.com:gamechanger/dusty.git
+    * Added support for SCP style GitHub urls. Example: git@github.com:gamechanger/dusty.git
 * **Misc**
     * Added support for Docker Compose 1.6
     * `dusty disk restore` now appends the `dusty-backup` suffix to the restore path if not provided, which should make the `restore` command a bit more intuitive to use

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 * **New**
     * Added `--only` flag to `bundles activate` which makes it easier to turn on a selection of bundles and deactivate all others
+    * Added support for scp style github urls as seen on github code pages. Example: git@github.com:gamechanger/dusty.git
 * **Misc**
     * Added support for Docker Compose 1.6
     * `dusty disk restore` now appends the `dusty-backup` suffix to the restore path if not provided, which should make the `restore` command a bit more intuitive to use

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 * **New**
     * Added `--only` flag to `bundles activate` which makes it easier to turn on a selection of bundles and deactivate all others
-    * Added support for scp style github urls as seen on github code pages. Example: git@github.com:gamechanger/dusty.git
+    * Added support for SCP style GitHub urls as seen on github. Example: git@github.com:gamechanger/dusty.git
 * **Misc**
     * Added support for Docker Compose 1.6
     * `dusty disk restore` now appends the `dusty-backup` suffix to the restore path if not provided, which should make the `restore` command a bit more intuitive to use

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,9 +10,7 @@ here should be fine. Setting this to `root` is probably a **bad** idea.
 
 #### Specs Repo
 
-Dusty needs to know where your Dusty specs live.  You can enter a git
-repository here if you want to manage them that way (recommended).  You
-can also just specify a local file path.
+Dusty needs to know where your Dusty specs live.  See [this link](./specs/app-specs.md#repo) on how to specify git urls.
 
 If you're new to Dusty and would like to try things out, leave this blank
 to use the example specs.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -10,7 +10,15 @@ here should be fine. Setting this to `root` is probably a **bad** idea.
 
 #### Specs Repo
 
-Dusty needs to know where your Dusty specs live.  See [this link](./specs/app-specs.md#repo) on how to specify git urls.
+Dusty needs to know where your Dusty specs live.  Use a pattern similar to:
+```
+repo: file:///local/repo/path
+  -or-
+repo: https://github.com/my-org/my-app.git
+  -or-
+repo: git@github.com:my-org/my-app.git
+```
+to specify the Dusty specs' location.
 
 If you're new to Dusty and would like to try things out, leave this blank
 to use the example specs.

--- a/docs/specs/app-specs.md
+++ b/docs/specs/app-specs.md
@@ -19,7 +19,7 @@ repo: https://github.com/my-org/my-app.git
   -or-
 repo: /Users/myuser/my-app
   -or-
-repo: git@github.com:my-org/my-app.git
+repo: <github_user>@git_server.com:my-org/my-app.git
   -or-
 repo: ssh://<github_user>@github.com/my-org/my-app.git
 ```

--- a/docs/specs/app-specs.md
+++ b/docs/specs/app-specs.md
@@ -11,6 +11,8 @@ You can tell Dusty to use your own locally checked out copy of the source using 
 ## repo
 
 ```
+repo: file:///local/repo/path
+  -or-
 repo: github.com/my-org/my-app
   -or-
 repo: https://github.com/my-org/my-app.git

--- a/docs/specs/app-specs.md
+++ b/docs/specs/app-specs.md
@@ -16,6 +16,10 @@ repo: github.com/my-org/my-app
 repo: https://github.com/my-org/my-app.git
   -or-
 repo: /Users/myuser/my-app
+  -or-
+repo: git@github.com:my-org/my-app.git
+  -or-
+repo: ssh://<github_user>@github.com/my-org/my-app.git
 ```
 
 `repo` specifies the repo containing the source for an app. By default, Dusty manages this

--- a/dusty/source.py
+++ b/dusty/source.py
@@ -111,17 +111,17 @@ class Repo(object):
             if self.remote_path.startswith('file:///'):
                 return self.remote_path
             else:
-                return 'file:///{}'.format(self.remote_path)
+                return 'file://{}'.format(self.remote_path)
         elif self.is_http_repo:
             if self.remote_path.endswith('.git'):
                 return self.remote_path
             else:
                 return self.remote_path + '.git'
-        else:
-            if self.remote_path.startswith('ssh://'):
+
+        if self.remote_path.startswith('ssh://') or '@' in self.remote_path:
                 return self.remote_path
-            else:
-                return 'ssh://{}@{}'.format(constants.GIT_USER, self.remote_path)
+
+        return 'ssh://{}@{}'.format(constants.GIT_USER, self.remote_path)
 
     def ensure_local_repo(self):
         """Given a Dusty repo object, clone the remote into Dusty's local repos

--- a/tests/unit/source_test.py
+++ b/tests/unit/source_test.py
@@ -126,7 +126,7 @@ class TestSource(DustyTestCase):
         temp_dir = os.path.join(self.temp_dir, 'c')
         self.MockableRepo.managed_path = property(lambda repo: temp_dir)
         self.MockableRepo('/tmp/repo-c').ensure_local_repo()
-        fake_clone_from.assert_called_with('file:////tmp/repo-c', temp_dir)
+        fake_clone_from.assert_called_with('file:///tmp/repo-c', temp_dir)
 
     @patch('git.Repo.clone_from')
     def test_ensure_local_repo_when_does_not_exist_with_https_remote(self, fake_clone_from):
@@ -174,3 +174,60 @@ class TestSource(DustyTestCase):
         fake_repo.return_value = repo_mock
         Repo('github.com/app/a').update_local_repo()
         pull_mock.pull.assert_called_once_with('master')
+
+    def test_assemble_remote_path_1(self):
+        repo_url = 'file:///path/to/repo'
+        repo = Repo(repo_url)
+        expected_url = 'file:///path/to/repo'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_2(self):
+        repo_url = '/path/to/repo'
+        repo = Repo(repo_url)
+        expected_url = 'file:///path/to/repo'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_3(self):
+        repo_url = 'http://path/to/repo.git'
+        repo = Repo(repo_url)
+        expected_url = 'http://path/to/repo.git'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_4(self):
+        repo_url = 'http://path/to/repo'
+        repo = Repo(repo_url)
+        expected_url = 'http://path/to/repo.git'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_5(self):
+        repo_url = 'ssh://path/to/repo/more_stuff'
+        repo = Repo(repo_url)
+        expected_url = 'ssh://path/to/repo/more_stuff'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_6(self):
+        repo_url = 'ssh://path/to/repo:80/more_stuff'
+        repo = Repo(repo_url)
+        expected_url = 'ssh://path/to/repo:80/more_stuff'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_7(self):
+        repo_url = 'git@path/to/repo:more_stuff'
+        repo = Repo(repo_url)
+        expected_url = 'git@path/to/repo:more_stuff'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_8(self):
+        repo_url = 'path/to/repo'
+        repo = Repo(repo_url)
+        expected_url = 'ssh://git@path/to/repo'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+

--- a/tests/unit/source_test.py
+++ b/tests/unit/source_test.py
@@ -211,23 +211,37 @@ class TestSource(DustyTestCase):
         self.assertEqual(repo.assemble_remote_path(), expected_url)
 
     def test_assemble_remote_path_6(self):
-        repo_url = 'ssh://path/to/repo:80/more_stuff'
+        repo_url = 'ssh://git@path/to/repo:80/more_stuff'
         repo = Repo(repo_url)
-        expected_url = 'ssh://path/to/repo:80/more_stuff'
+        expected_url = 'ssh://git@path/to/repo:80/more_stuff'
 
         self.assertEqual(repo.assemble_remote_path(), expected_url)
 
     def test_assemble_remote_path_7(self):
+        repo_url = 'ssh://user@path/to/repo:80/more_stuff'
+        repo = Repo(repo_url)
+        expected_url = 'ssh://user@path/to/repo:80/more_stuff'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_8(self):
         repo_url = 'git@path/to/repo:more_stuff'
         repo = Repo(repo_url)
         expected_url = 'git@path/to/repo:more_stuff'
 
         self.assertEqual(repo.assemble_remote_path(), expected_url)
 
-    def test_assemble_remote_path_8(self):
+    def test_assemble_remote_path_9(self):
         repo_url = 'path/to/repo'
         repo = Repo(repo_url)
         expected_url = 'ssh://git@path/to/repo'
+
+        self.assertEqual(repo.assemble_remote_path(), expected_url)
+
+    def test_assemble_remote_path_10(self):
+        repo_url = 'alex@path/to/repo:more_stuff'
+        repo = Repo(repo_url)
+        expected_url = 'alex@path/to/repo:more_stuff'
 
         self.assertEqual(repo.assemble_remote_path(), expected_url)
 


### PR DESCRIPTION
review @thieman  I added support for scp style github urls like: git@github.com:gamechanger/dusty.git

This implements: https://github.com/gamechanger/dusty/issues/624 and fixes lingering issues from: https://github.com/gamechanger/dusty/issues/539

I do not think we need to change any of our example dusty specs documentation because url should now just work. 