### PR TITLE
Fix bugs with env and down machine on required login

### DIFF
--- a/dusty/commands/run.py
+++ b/dusty/commands/run.py
@@ -26,6 +26,7 @@ def prep_for_start_local_env(pull_repos):
     assembled_spec = spec_assembler.get_assembled_specs()
     if not assembled_spec[constants.CONFIG_BUNDLES_KEY]:
         raise RuntimeError('No bundles are activated. Use `dusty bundles` to activate bundles before running `dusty up`.')
+    virtualbox.initialize_docker_vm()
 
 def log_in_to_required_registries():
     """Client-side command which runs the user through a login flow
@@ -49,8 +50,6 @@ def start_local_env(recreate_containers):
     local environment go."""
 
     assembled_spec = spec_assembler.get_assembled_specs()
-    virtualbox.initialize_docker_vm()
-
     required_absent_assets = virtualbox.required_absent_assets(assembled_spec)
     if required_absent_assets:
         raise RuntimeError('Assets {} are specified as required but are not set. Set them with `dusty assets set`'.format(required_absent_assets))

--- a/dusty/systems/docker/config.py
+++ b/dusty/systems/docker/config.py
@@ -10,6 +10,7 @@ from ... import constants
 from ...log import log_to_client
 from ...memoize import memoized
 from ...subprocess import check_call_demoted
+from . import get_docker_env
 
 def registry_from_image(image_name):
     """Returns the Docker registry host associated with
@@ -59,7 +60,7 @@ def log_in_to_registry(registry):
             args.append(registry)
 
         try:
-            check_call_demoted(['docker', 'login'] + args)
+            check_call_demoted(['docker', 'login'] + args, env=get_docker_env())
         except CalledProcessError:
             log_to_client('\nLogin failed, please try again for {} (Ctrl-C to quit)\n'.format(registry))
         else:


### PR DESCRIPTION
@paetling Fixes the bugs that @mugli identified in #626. This makes sure the VM is initialized before trying to log in, and it passes the Docker envvars to the login command. I thought this was getting done automatically, but calling the Docker binary as a subprocess is actually a new flow for us (in other instances we either use the Python client or `exec` out to replace the Dusty process). Will cut a RC after this is merged.