### PR TITLE
Shut down HTTP server at upgrade to avoid immortal thread

### DIFF
--- a/dusty/commands/upgrade.py
+++ b/dusty/commands/upgrade.py
@@ -8,7 +8,7 @@ import urllib
 import psutil
 
 from .. import constants
-from ..daemon import close_client_connection, clean_up_socket
+from ..daemon import close_client_connection, clean_up_socket, shut_down_http_server
 from ..log import log_to_client
 from ..payload import daemon_command
 from ..subprocess import check_and_log_output_and_error
@@ -87,6 +87,7 @@ def upgrade_dusty_binary(version=None):
     final_binary_path = _move_temp_binary_to_path(tmp_binary_path)
     log_to_client('Finished upgrade to version {} of Dusty!  The daemon will now restart'.format(version))
     log_to_client('You may need to run `dusty up` to fully complete the upgrade')
+    shut_down_http_server()
     close_client_connection()
     clean_up_socket()
     os.execvp(final_binary_path, [final_binary_path, '-d'])

--- a/dusty/daemon.py
+++ b/dusty/daemon.py
@@ -62,10 +62,22 @@ def close_client_connection(terminator=SOCKET_TERMINATOR):
         close_socket_logger()
         connection.close()
 
+def shut_down_http_server():
+    logging.info('Daemon is shutting down HTTP server')
+    try:
+        r = requests.post('http://{}:{}/shutdown'.format(constants.DAEMON_HTTP_BIND_IP,
+                                                         constants.DAEMON_HTTP_BIND_PORT),
+                          timeout=2)
+        r.raise_for_status()
+    except Exception as e:
+        logging.exception('Exception trying to shut down HTTP server')
+
 def _start_http_server():
     """Start the daemon's HTTP server on a separate thread.
     This server is only used for servicing container status
     requests from Dusty's custom 502 page."""
+    logging.info('Starting HTTP server at {}:{}'.format(constants.DAEMON_HTTP_BIND_IP,
+                                                        constants.DAEMON_HTTP_BIND_PORT))
     thread = threading.Thread(target=http_server.app.run, args=(constants.DAEMON_HTTP_BIND_IP,
                                                                 constants.DAEMON_HTTP_BIND_PORT))
     thread.daemon = True

--- a/dusty/http_server.py
+++ b/dusty/http_server.py
@@ -25,6 +25,15 @@ def _app_name_from_forwarding_info(hostname, port):
                 return app.name
     raise ValueError('Could not find app for {}:{}'.format(hostname, port))
 
+@app.route('/shutdown', methods=['POST'])
+def shutdown():
+    logging.info('Received POST request to shut down HTTP server')
+    shutdown_function = request.environ.get('werkzeug.server.shutdown')
+    if shutdown_function is None:
+        raise RuntimeError('Not running with the Werkzeug Server')
+    shutdown_function()
+    return 'Dusty HTTP server shutting down'
+
 @app.route('/register-consumer', methods=['POST'])
 def register_consumer():
     """Given a hostname and port attempting to be accessed,

--- a/requirements.py
+++ b/requirements.py
@@ -7,6 +7,7 @@ install_requires = [
     'Schemer==0.2.9',
     'psutil==2.2.1',
     'Flask==0.10.1',
+    'requests==2.9.1',
 ]
 
 test_requires = [


### PR DESCRIPTION
@jsingle Turns out `exec` and threads play about as well together as `fork` and threads do. During upgrade flow, we need to make sure to shut down the HTTP server, or we lose track of it completely (and it never dies) once we `exec` to the new binary.