### PR TITLE
Close file descriptors on all subprocess calls

### DIFF
--- a/dusty/subprocess.py
+++ b/dusty/subprocess.py
@@ -33,7 +33,7 @@ def run_subprocess(fn, shell_args, demote=True, env=None, **kwargs):
         passed_env = None
     if demote:
         kwargs['preexec_fn'] = _demote_to_user(get_config_value(constants.CONFIG_MAC_USERNAME_KEY))
-    output = fn(shell_args, env=passed_env, **kwargs)
+    output = fn(shell_args, env=passed_env, close_fds=True, **kwargs)
     return output
 
 def call_demoted(shell_args, env=None, redirect_stderr=False):


### PR DESCRIPTION
@paetling Subprocess works through a fork and then an exec. The fork copies the calling process, including our file descriptors (like our open port). Nothing in exec does anything to close these. This PR politely tells Python to close them for us whenever we invoke a subprocess through our helper functions. This fixes the issue where we saw VirtualBox holding on to the HTTP server's port. We forked to Docker Machine, which still had our FDs, which then forked to VBox to start the machine, then VBox still had our FDs.

I still don't totally understand why this is defaulted to False, it seems to me like in most straight-up subprocess cases (i.e. not forking to clone yourself) you'd want to close. Might research that further.