### PR TITLE
Increase daemon's file handles to 8192

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
     * Added a custom 502 page for apps which use host forwarding. This lets you see the status and logs of your container while you're waiting for its HTTP service to come online
 * **Misc**
     * Implemented a [networking fix](https://github.com/docker/machine/pull/3112) the Dusty team implemented in Docker Machine within Dusty
+    * The daemon now raises its open file handle limit to 8192, which should prevent some OSErrors during parallelized Git operations
 
 ## 0.7.0 (February 18, 2016)
 

--- a/dusty/constants.py
+++ b/dusty/constants.py
@@ -30,6 +30,8 @@ SOCKET_PATH = os.getenv('DUSTY_SOCKET_PATH', os.path.join(RUN_DIR, 'dusty.sock')
 DAEMON_HTTP_BIND_IP = '127.0.0.1'
 DAEMON_HTTP_BIND_PORT = 60912
 
+FILE_HANDLE_LIMIT = 8192
+
 FIRST_RUN_FILE_PATH = '/.dusty_first_time_started'
 CONTAINER_LOG_PATH = "/var/log"
 


### PR DESCRIPTION
@jsingle Finally found what I was looking for here. I believe this should play nicely with OS X under its default settings and should stop the open file errors we've been seeing during parallelized Git operations.