### PR TITLE
Use $http_host instead of $host in nginx config

### DIFF
--- a/dusty/compiler/nginx/__init__.py
+++ b/dusty/compiler/nginx/__init__.py
@@ -12,7 +12,7 @@ def _nginx_location_spec(port_spec, bridge_ip):
                              'proxy_set_header Upgrade $http_upgrade;',
                              'proxy_set_header Connection "upgrade";',
                              'proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;',
-                             'proxy_set_header Host $host;',
+                             'proxy_set_header Host $http_host;',
                              _nginx_proxy_string(port_spec, bridge_ip)]:
         location_string_spec += "\t \t \t {} \n".format(location_setting)
     location_string_spec += "\t \t } \n"

--- a/tests/unit/compiler/nginx/init_test.py
+++ b/tests/unit/compiler/nginx/init_test.py
@@ -32,7 +32,7 @@ class TestPortSpecCompiler(DustyTestCase):
                     proxy_set_header Upgrade $http_upgrade;
                     proxy_set_header Connection "upgrade";
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                    proxy_set_header Host $host;
+                    proxy_set_header Host $http_host;
                     proxy_pass http://172.17.42.1:80;
                 }
 
@@ -57,7 +57,7 @@ class TestPortSpecCompiler(DustyTestCase):
                     proxy_set_header Upgrade $http_upgrade;
                     proxy_set_header Connection "upgrade";
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                    proxy_set_header Host $host;
+                    proxy_set_header Host $http_host;
                     proxy_pass http://172.17.42.1:8000;
                 }
 
@@ -91,7 +91,7 @@ class TestPortSpecCompiler(DustyTestCase):
                     proxy_set_header Upgrade $http_upgrade;
                     proxy_set_header Connection "upgrade";
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                    proxy_set_header Host $host;
+                    proxy_set_header Host $http_host;
                     proxy_pass http://172.17.42.1:8000;
                 }
 
@@ -110,7 +110,7 @@ class TestPortSpecCompiler(DustyTestCase):
                     proxy_set_header Upgrade $http_upgrade;
                     proxy_set_header Connection "upgrade";
                     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                    proxy_set_header Host $host;
+                    proxy_set_header Host $http_host;
                     proxy_pass http://172.17.42.1:80;
                 }
 


### PR DESCRIPTION
@jsingle Fixes #662. This makes host forwarding work better when apps are forwarded on a local port other than 80. http://stackoverflow.com/questions/15414810/whats-the-difference-of-host-and-http-host-in-nginx