### PR TITLE
Remove extraneous utf-8 decode in CLI socket recv

### DIFF
--- a/dusty/cli/__init__.py
+++ b/dusty/cli/__init__.py
@@ -84,7 +84,7 @@ def _run_command(sock, command):
         data = sock.recv(65535)
         timer.cancel()
         if data:
-            stripped = data.decode('utf-8').replace(constants.SOCKET_ACK, '').replace(constants.SOCKET_TERMINATOR, '').replace(constants.SOCKET_ERROR_TERMINATOR, '')
+            stripped = data.replace(constants.SOCKET_ACK, '').replace(constants.SOCKET_TERMINATOR, '').replace(constants.SOCKET_ERROR_TERMINATOR, '')
             sys.stdout.write(stripped)
             if data.endswith(constants.SOCKET_TERMINATOR):
                 break


### PR DESCRIPTION
@jsingle This was causing non-ASCII encodable output from the socket to throw encoding errors when run under the binary. Did not affect Dusty being run from source. Related PyInstaller issue is here: https://github.com/pyinstaller/pyinstaller/issues/1240

Issue is that `sys.stdout` doesn't get a default encoding under PyInstaller, so it was getting a unicode object (which is what you get from decoding a string), then trying to encode that as ASCII, the default encoding if `sys.stdout` doesn't specify one.