### PR TITLE
/usr/local/bin not writeable by non-root (default)

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -6,16 +6,19 @@ LEGACY_INSTALL_ROOT=/System/Library/LaunchDaemons
 LEGACY_PLIST_NAME=org.gamechanger.dusty.plist
 INSTALL_ROOT=/Library/LaunchDaemons
 PLIST_NAME=com.gamechanger.dusty.plist
+TMP_DIR=`mktemp -d`
 
 function bold_echo {
     echo -e "\033[1m$1\033[0m"
 }
 
 bold_echo "Downloading dusty binary"
-curl -L https://github.com/gamechanger/dusty/releases/download/$release/dusty > /usr/local/bin/dusty
-chmod +x /usr/local/bin/dusty
+curl -L https://github.com/gamechanger/dusty/releases/download/$release/dusty > $TMP_DIR/dusty
+chmod +x $TMP_DIR/dusty
 bold_echo "Authenticating as super user... needed to setup daemon"
 sudo -v
+bold_echo "Moving dusty binary into place"
+sudo mv -f $TMP_DIR/dusty /usr/local/bin/dusty
 bold_echo "Resetting dusty daemon"
 sudo curl -L -o $INSTALL_ROOT/$PLIST_NAME https://raw.githubusercontent.com/gamechanger/dusty/$release/setup/$PLIST_NAME
 sudo launchctl unload $INSTALL_ROOT/$PLIST_NAME


### PR DESCRIPTION
Homebrew sets /usr/local/bin to be writable by the user, however this is not the default permission; in that case, installing will fail. (Homebrew changes the permissions of /usr/local/bin—seems bad but ok)

Instead, write binary to a tmp file, and move it into place after escalating privs.

r? @thieman 