### PR TITLE
Ns upgrade python git

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## 0.7.2 (In Progress)
+* **Misc**
+    * Upgraded the version of GitPython that dusty is using from 1.0.1 -> 2.1.9.  This should fix an issue with how git response were being parsed, leading to dusty failing to manage its own repositories on newer Apple computers.
+    * A fix to the install script that will make it install to a temp directory, then copy over the installed binary with correct permissions to the intended installation directory.
+    * A more robust solition to parsing the `RepoTags` configuration for testing.
 
 ## 0.7.1 (April 14, 2016)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 * **Misc**
     * Upgraded the version of GitPython that dusty is using from 1.0.1 -> 2.1.9.  This should fix an issue with how git response were being parsed, leading to dusty failing to manage its own repositories on newer Apple computers.
     * A fix to the install script that will make it install to a temp directory, then copy over the installed binary with correct permissions to the intended installation directory.
-    * A more robust solition to parsing the `RepoTags` configuration for testing.
+    * A more robust solution to parsing the `RepoTags` configuration for testing.
 
 ## 0.7.1 (April 14, 2016)
 

--- a/requirements.py
+++ b/requirements.py
@@ -2,7 +2,7 @@ install_requires = [
     'docker-py==1.7.0',
     'PyYAML==3.11',
     'PrettyTable==0.7.0',
-    'GitPython==1.0.1',
+    'GitPython==2.1.9',
     'docopt==0.6.2',
     'Schemer==0.2.9',
     'psutil==2.2.1',


### PR DESCRIPTION
@paetling I tested this change on @MaxMikheyenko's computer, it looks like it solves the problem we have been seeing around dusty failing to manage repositories on newer apple computers