### PR TITLE
refactor(docker-py): upgrade to 1.10.6

### DIFF
--- a/requirements.py
+++ b/requirements.py
@@ -1,5 +1,5 @@
 install_requires = [
-    'docker-py==1.7.0',
+    'docker-py==1.10.6',
     'PyYAML==3.11',
     'PrettyTable==0.7.0',
     'GitPython==2.1.9',


### PR DESCRIPTION
@confucious this fixes an issue I was seeing with `dusty logs`
```
Traceback (most recent call last):
  File "dusty", line 2, in <module>

  File "dusty/cli/__init__.py", line 159, in main
    errored = _run_payload(result)
  File "dusty/cli/__init__.py", line 130, in _run_payload
    payload.run()
  File "dusty/payload.py", line 21, in run
    self.fn(*self.args, **self.kwargs)
  File "dusty/commands/logs.py", line 6, in tail_container_logs
    containers = get_dusty_containers([app_or_service_name], include_exited=True)
  File "dusty/systems/docker/__init__.py", line 66, in get_dusty_containers
    client = get_docker_client()
  File "dusty/memoize.py", line 22, in memoizer
    cache[key] = fn(*args, **kwargs)
  File "dusty/systems/docker/__init__.py", line 60, in get_docker_client
    return docker.Client(**params)
  File "site-packages/docker/client.py", line 56, in __init__
  File "site-packages/docker/auth/auth.py", line 182, in load_config
  File "site-packages/docker/auth/auth.py", line 118, in parse_auth
TypeError: string indices must be integers
[84979] Failed to execute script dusty
```